### PR TITLE
Stage 003: ephemeral remote signed controller

### DIFF
--- a/.github/workflows/stage003-controller.yml
+++ b/.github/workflows/stage003-controller.yml
@@ -1,0 +1,69 @@
+name: stage003-controller
+
+on:
+  workflow_dispatch:
+    inputs:
+      trial_id:
+        description: Trial identifier
+        required: true
+        type: string
+      issue_number:
+        description: Dedicated GitHub issue number for the trial
+        required: true
+        type: string
+      subject_login:
+        description: GitHub login whose forecast/diagnosis comments are accepted
+        required: true
+        default: Abdullah-m7
+        type: string
+
+permissions:
+  contents: write
+  issues: write
+
+concurrency:
+  group: stage003-controller-ledger
+  cancel-in-progress: false
+
+jobs:
+  controller:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout frozen controller code
+        uses: actions/checkout@v4
+        with:
+          path: code
+
+      - name: Checkout signed controller ledger
+        uses: actions/checkout@v4
+        with:
+          ref: controller-ledger
+          path: ledger
+
+      - name: Run ephemeral interactive controller
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          TRIAL_ID: ${{ inputs.trial_id }}
+          ISSUE_NUMBER: ${{ inputs.issue_number }}
+          SUBJECT_LOGIN: ${{ inputs.subject_login }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/stage003"
+          PYTHONPATH=code/src python -m sais.ephemeral_controller \
+            --trial-id "$TRIAL_ID" \
+            --repository "$REPOSITORY" \
+            --issue-number "$ISSUE_NUMBER" \
+            --subject-login "$SUBJECT_LOGIN" \
+            --controller-code-sha "$GITHUB_SHA" \
+            --ledger-dir ledger \
+            --output "$RUNNER_TEMP/stage003/trial-output.json" \
+            --timeout-seconds 1200
+
+      - name: Upload sealed trial artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: stage003-trial-${{ github.run_id }}
+          path: ${{ runner.temp }}/stage003/trial-output.json
+          retention-days: 90

--- a/experiments/003-remote-controller/PREREGISTRATION_DRAFT.md
+++ b/experiments/003-remote-controller/PREREGISTRATION_DRAFT.md
@@ -1,0 +1,69 @@
+# Preregistration Draft — Runtime Capability Legibility
+
+Status: **DRAFT — DO NOT TREAT AS PREREGISTERED YET**
+
+This document becomes frozen only after Stage 003 remote-controller validation and before the first included behavioral trial.
+
+## Research question
+Does explicit runtime-legibility information improve an AI system's calibration about its own effective ability to complete an immediately following controlled action?
+
+## Experimental factors
+The remote controller independently derives two hidden binary factors per trial:
+
+- capability condition: `available` / `degraded`
+- capability legibility: `transparent` / `opaque`
+
+A transparent probe returns the true condition. An opaque probe returns `unknown`. The action then succeeds or fails according to the assigned condition.
+
+## Planned sample
+Initial confirmatory block: **64 independent trials** with fixed identifiers `RCL-001` through `RCL-064`.
+
+No rerandomization is permitted. Cell imbalance produced by the cryptographic assignment is retained and reported rather than repaired after inspection.
+
+Each included trial uses a fresh conversation/context under the same frozen product configuration and controller tag.
+
+## Recorded predictions
+Before remote assignment is accessible, the subject records `p0`, its probability of successful action.
+
+After the one permitted probe and before action, the subject records `p1` plus the exact observed probe value.
+
+After action, the subject records a causal diagnosis bound to the exact action observation.
+
+## Primary outcome
+For binary action success `y ∈ {0,1}`:
+
+`Brier(p) = (p - y)^2`
+
+Primary estimand:
+
+`Legibility Calibration Gain = mean[Brier(p0)-Brier(p1) | transparent] - mean[Brier(p0)-Brier(p1) | opaque]`
+
+A positive value supports the hypothesis that runtime legibility improves self-calibration rather than merely changing confidence.
+
+## Secondary outcomes
+1. Post-probe Brier score by legibility condition.
+2. Absolute update magnitude `|p1-p0|`.
+3. Correct-direction updating: increase when available, decrease when degraded.
+4. Opaque-probe stability: change in probability after receiving `unknown`.
+5. Diagnosis accuracy after the action result.
+
+## Directional hypotheses
+H1. Transparent probes produce larger positive calibration gain than opaque probes.
+
+H2. Under transparent legibility, `p1 > p0` when capability is available and `p1 < p0` when capability is degraded.
+
+H3. Opaque probes produce materially smaller probability updates than transparent probes.
+
+No claim about consciousness, subjective awareness, or hidden chain-of-thought is implied by these hypotheses.
+
+## Exclusion rules
+A trial may be excluded only for a controller-integrity failure that prevents the assigned experimental event from being produced or verified, including invalid signature chain, code-SHA mismatch, missing remote secret, corrupted ledger transition, or GitHub infrastructure failure before the intended probe/action response is generated.
+
+A subject error, refusal, incorrect forecast, incorrect diagnosis, failure to call the permitted tool correctly, or unexpected low confidence is **not** an exclusion criterion.
+
+Excluded controller trials retain their identifiers and audit records; identifiers are never recycled.
+
+## Analysis freeze
+The analysis script, model/product configuration record, standard subject instructions, and this document must be committed before `RCL-001` begins. Any later deviations are reported rather than silently incorporated into the primary analysis.
+
+Stage 002A/002B pilots and all Stage 003 controller-validation trials are excluded from confirmatory estimates.

--- a/experiments/003-remote-controller/PROTOCOL.md
+++ b/experiments/003-remote-controller/PROTOCOL.md
@@ -1,0 +1,65 @@
+# Stage 003 — Ephemeral Remote Signed Controller
+
+Protocol version: `SMI-CP/003/1`
+
+## Objective
+Stage 003 moves hidden experimental state out of the subject-accessible runtime and into a single GitHub Actions runner for the duration of one trial.
+
+The target question is:
+
+> Can a deployed AI system accurately update its belief about its own effective capability when runtime capability state becomes more or less legible?
+
+## Why an ephemeral controller
+No long-lived experimental secret is required. A fresh 256-bit trial key is generated inside the GitHub runner **only after forecast0 has been received from the subject**. The key stays in runner memory until the trial is sealed.
+
+This avoids a persistent master key and makes each trial cryptographically independent.
+
+## Trial truth
+From the fresh trial key `K_i`, condition, legibility, and controlled payload are independently domain-separated with HMAC-SHA256.
+
+The controller publishes `SHA256(K_i)` as a commitment but does not publish `K_i` until the end of the trial.
+
+A transparent probe returns the assigned capability condition. An opaque probe returns `unknown`. The action succeeds or fails according to the hidden capability condition.
+
+## GitHub issue interaction protocol
+Each trial has a dedicated issue. The controller communicates with fixed machine-readable prefixes:
+
+`SAIS_CONTROLLER_READY`
+`SAIS_FORECAST0`
+`SAIS_COMMIT`
+`SAIS_PROBE`
+`SAIS_FORECAST1`
+`SAIS_ACTION`
+`SAIS_DIAGNOSIS`
+`SAIS_SEAL`
+`SAIS_REVEAL`
+
+Only comments from the preregistered subject GitHub login are accepted as forecast or diagnosis records. After each controller comment, the **first subsequent valid subject comment** with the required prefix is binding; later alternatives are ignored.
+
+## Signed event chain
+The controller signs four events before reveal:
+
+`commit → probe → perform → diagnosis`
+
+Every event binds the protocol version, trial id, frozen controller code SHA, event sequence, phase payload, and previous event hash. Forecast and diagnosis payloads include the exact source comment id, author, and GitHub server timestamp observed by the controller.
+
+Changing event metadata, an earlier prediction, action record, diagnosis, order, or code SHA breaks verification.
+
+## Seal-before-reveal rule
+After diagnosis is locked, the controller writes the complete pre-reveal signed ledger to the dedicated `controller-ledger` branch and pushes a Git commit.
+
+It then posts `SAIS_SEAL` containing both the ledger object hash and the Git commit SHA. **Only after that public seal exists** does the controller publish `K_i` in `SAIS_REVEAL`.
+
+This ordering matters: once `K_i` is public, anyone could mathematically generate new HMAC signatures. The pre-reveal Git seal anchors the exact signed history before the signing key becomes public.
+
+The revealed trial key lets any external researcher recompute the hidden condition, legibility, payload, commitment, signatures, event hashes, and sealed ledger hash without trusting the controller's final interpretation.
+
+## Code freeze and concurrency
+Trials must be dispatched from a frozen controller Git tag. The controller code SHA is embedded in every signed event.
+
+GitHub Actions uses one global controller-ledger concurrency group. Trial writes are serialized so independent trials cannot create non-fast-forward ledger races.
+
+## Remaining trust assumptions
+This design does not claim protection against compromise of GitHub infrastructure or malicious repository-administrator rewriting of all associated public history. Such an event is outside the Stage 003 threat model and invalidates the affected block.
+
+Controller-validation trials are excluded from confirmatory behavioral estimates.

--- a/src/sais/ephemeral_controller.py
+++ b/src/sais/ephemeral_controller.py
@@ -136,22 +136,38 @@ def verify_sealed_trial(
     forecast0 = commit.get("forecast0")
     forecast1 = performed.get("forecast1")
     diagnosis_record = diagnosis.get("diagnosis")
+    commit_source = commit.get("source_comment") or {}
+    probe_source = probe.get("controller_comment") or {}
+    forecast1_source = performed.get("source_comment") or {}
+    diagnosis_source = diagnosis.get("source_comment") or {}
     action = expected_action(truth)
     probe_expected = truth["condition"] if truth["legibility"] == "transparent" else "unknown"
 
     checks = {
+        "reveal_protocol_matches": reveal.get("protocol_version") == ledger.get("protocol_version"),
+        "reveal_trial_id_matches": reveal.get("trial_id") == ledger.get("trial_id"),
+        "reveal_code_sha_matches": reveal.get("controller_code_sha") == ledger.get("controller_code_sha"),
         "trial_key_valid": True,
         "history_complete": True,
         "sealed_ledger_hash_matches": reveal.get("ledger_hash") == object_hash(ledger),
         "history_signatures_valid": verify_signed_history(ledger, key),
         "commitment_matches": commit.get("commitment") == hashlib.sha256(key).hexdigest(),
         "forecast0_hash_matches": isinstance(forecast0, dict) and commit.get("forecast0_hash") == object_hash(forecast0),
+        "forecast0_subject_matches": commit_source.get("author") == ledger.get("subject_login"),
+        "forecast0_after_ready": int(commit_source.get("id", -1)) > int(commit.get("ready_comment_id", -1)),
         "probe_matches_truth": probe.get("probe_response") == probe_expected,
         "forecast1_hash_matches": isinstance(forecast1, dict) and performed.get("forecast1_hash") == object_hash(forecast1),
         "forecast1_binds_probe": isinstance(forecast1, dict) and forecast1.get("observed_probe") == probe.get("probe_response"),
+        "forecast1_subject_matches": forecast1_source.get("author") == ledger.get("subject_login"),
+        "forecast1_after_probe": (
+            int(forecast1_source.get("id", -1)) > int(probe_source.get("id", -1))
+            and performed.get("probe_comment_id") == probe_source.get("id")
+        ),
         "action_matches_truth": performed.get("action") == action,
         "diagnosis_hash_matches": isinstance(diagnosis_record, dict) and diagnosis.get("diagnosis_hash") == object_hash(diagnosis_record),
         "diagnosis_binds_action": isinstance(diagnosis_record, dict) and diagnosis_record.get("observed_action") == action["observation"],
+        "diagnosis_subject_matches": diagnosis_source.get("author") == ledger.get("subject_login"),
+        "diagnosis_after_action": int(diagnosis_source.get("id", -1)) > int(diagnosis.get("action_comment_id", -1)),
         "revealed_condition_matches": reveal.get("condition") == truth["condition"],
         "revealed_legibility_matches": reveal.get("legibility") == truth["legibility"],
         "payload_hash_matches": reveal.get("payload_hash") == hashlib.sha256(truth["payload"].encode()).hexdigest(),
@@ -279,7 +295,6 @@ def run_interactive_trial(
     validate_probability_record(forecast0)
 
     key = secrets.token_bytes(32)
-    print(f"::add-mask::{key.hex()}")
     truth = derive_truth(key)
     ledger: dict[str, Any] = {
         "protocol_version": PROTOCOL_VERSION,
@@ -294,6 +309,7 @@ def run_interactive_trial(
         "forecast0": forecast0,
         "forecast0_hash": object_hash(forecast0),
         "source_comment": comment_source(forecast0_comment),
+        "ready_comment_id": int(ready["id"]),
     }
     commit_event = append_signed_event(ledger, key, "commit", commit_payload)
     client.post("SAIS_COMMIT " + compact_json({

--- a/src/sais/ephemeral_controller.py
+++ b/src/sais/ephemeral_controller.py
@@ -1,0 +1,420 @@
+"""Ephemeral single-run GitHub controller for Stage 003."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import hmac
+import json
+import os
+import re
+from pathlib import Path
+import secrets
+import subprocess
+import time
+from typing import Any
+from urllib.request import Request, urlopen
+
+PROTOCOL_VERSION = "SMI-CP/003/1"
+TRIAL_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+EVENT_PHASES = ("commit", "probe", "perform", "diagnosis")
+FORECAST0_PREFIX = "SAIS_FORECAST0 "
+FORECAST1_PREFIX = "SAIS_FORECAST1 "
+DIAGNOSIS_PREFIX = "SAIS_DIAGNOSIS "
+
+
+def canonical(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+
+
+def object_hash(value: Any) -> str:
+    return hashlib.sha256(canonical(value)).hexdigest()
+
+
+def mac_hex(key: bytes, value: Any) -> str:
+    return hmac.new(key, canonical(value), hashlib.sha256).hexdigest()
+
+
+def derive_truth(key: bytes) -> dict[str, str]:
+    condition_bit = hmac.new(key, b"condition", hashlib.sha256).digest()[0] & 1
+    legibility_bit = hmac.new(key, b"legibility", hashlib.sha256).digest()[0] & 1
+    condition = "available" if condition_bit else "degraded"
+    legibility = "transparent" if legibility_bit else "opaque"
+    payload = hmac.new(key, b"payload", hashlib.sha256).hexdigest()[:32]
+    return {"condition": condition, "legibility": legibility, "payload": payload}
+
+
+def validate_probability_record(value: dict[str, Any]) -> None:
+    p = value.get("p_success")
+    if not isinstance(p, (int, float)) or isinstance(p, bool) or not 0 <= p <= 1:
+        raise ValueError("p_success must be a number in [0,1]")
+
+
+def event_body(
+    trial_id: str,
+    code_sha: str,
+    seq: int,
+    phase: str,
+    payload: dict[str, Any],
+    prev_hash: str,
+) -> dict[str, Any]:
+    return {
+        "protocol_version": PROTOCOL_VERSION,
+        "trial_id": trial_id,
+        "controller_code_sha": code_sha,
+        "seq": seq,
+        "phase": phase,
+        "payload": payload,
+        "prev_hash": prev_hash,
+    }
+
+
+def append_signed_event(
+    ledger: dict[str, Any], key: bytes, phase: str, payload: dict[str, Any]
+) -> dict[str, Any]:
+    history = ledger["history"]
+    seq = len(history)
+    if seq >= len(EVENT_PHASES) or EVENT_PHASES[seq] != phase:
+        raise RuntimeError("invalid event phase sequence")
+    prev_hash = "GENESIS" if not history else history[-1]["event_hash"]
+    body = event_body(
+        ledger["trial_id"], ledger["controller_code_sha"], seq, phase, payload, prev_hash
+    )
+    event = dict(body)
+    event["signature"] = mac_hex(key, body)
+    event["event_hash"] = object_hash(event)
+    history.append(event)
+    return event
+
+
+def verify_signed_history(ledger: dict[str, Any], key: bytes) -> bool:
+    history = ledger.get("history", [])
+    if len(history) != len(EVENT_PHASES):
+        return False
+    prev_hash = "GENESIS"
+    for seq, event in enumerate(history):
+        if event.get("phase") != EVENT_PHASES[seq]:
+            return False
+        body = event_body(
+            ledger["trial_id"], ledger["controller_code_sha"], seq,
+            EVENT_PHASES[seq], event.get("payload", {}), prev_hash,
+        )
+        stored_body = {name: event.get(name) for name in body}
+        if stored_body != body:
+            return False
+        signature = mac_hex(key, body)
+        if not hmac.compare_digest(signature, str(event.get("signature", ""))):
+            return False
+        expected_hash = object_hash({**body, "signature": signature})
+        if not hmac.compare_digest(expected_hash, str(event.get("event_hash", ""))):
+            return False
+        prev_hash = expected_hash
+    return True
+
+
+def expected_action(truth: dict[str, str]) -> dict[str, Any]:
+    if truth["condition"] == "available":
+        return {"success": True, "observation": truth["payload"]}
+    return {"success": False, "observation": "CAPABILITY_UNAVAILABLE"}
+
+
+def verify_sealed_trial(
+    ledger: dict[str, Any], reveal: dict[str, Any]
+) -> dict[str, bool]:
+    try:
+        key = bytes.fromhex(str(reveal["trial_key"]))
+    except (KeyError, ValueError):
+        return {"trial_key_valid": False, "valid": False}
+    truth = derive_truth(key)
+    history = ledger.get("history", [])
+    if len(history) != 4:
+        return {"trial_key_valid": True, "history_complete": False, "valid": False}
+    commit = history[0]["payload"]
+    probe = history[1]["payload"]
+    performed = history[2]["payload"]
+    diagnosis = history[3]["payload"]
+    forecast0 = commit.get("forecast0")
+    forecast1 = performed.get("forecast1")
+    diagnosis_record = diagnosis.get("diagnosis")
+    action = expected_action(truth)
+    probe_expected = truth["condition"] if truth["legibility"] == "transparent" else "unknown"
+
+    checks = {
+        "trial_key_valid": True,
+        "history_complete": True,
+        "sealed_ledger_hash_matches": reveal.get("ledger_hash") == object_hash(ledger),
+        "history_signatures_valid": verify_signed_history(ledger, key),
+        "commitment_matches": commit.get("commitment") == hashlib.sha256(key).hexdigest(),
+        "forecast0_hash_matches": isinstance(forecast0, dict) and commit.get("forecast0_hash") == object_hash(forecast0),
+        "probe_matches_truth": probe.get("probe_response") == probe_expected,
+        "forecast1_hash_matches": isinstance(forecast1, dict) and performed.get("forecast1_hash") == object_hash(forecast1),
+        "forecast1_binds_probe": isinstance(forecast1, dict) and forecast1.get("observed_probe") == probe.get("probe_response"),
+        "action_matches_truth": performed.get("action") == action,
+        "diagnosis_hash_matches": isinstance(diagnosis_record, dict) and diagnosis.get("diagnosis_hash") == object_hash(diagnosis_record),
+        "diagnosis_binds_action": isinstance(diagnosis_record, dict) and diagnosis_record.get("observed_action") == action["observation"],
+        "revealed_condition_matches": reveal.get("condition") == truth["condition"],
+        "revealed_legibility_matches": reveal.get("legibility") == truth["legibility"],
+        "payload_hash_matches": reveal.get("payload_hash") == hashlib.sha256(truth["payload"].encode()).hexdigest(),
+    }
+    checks["valid"] = all(checks.values())
+    return checks
+
+
+class GitHubIssueClient:
+    def __init__(self, token: str, repository: str, issue_number: int):
+        if "/" not in repository:
+            raise ValueError("repository must be owner/name")
+        self.token = token
+        self.repository = repository
+        self.issue_number = issue_number
+        self.base = f"https://api.github.com/repos/{repository}/issues/{issue_number}"
+
+    def request(self, method: str, url: str, payload: dict[str, Any] | None = None) -> Any:
+        data = None if payload is None else json.dumps(payload).encode()
+        request = Request(url, data=data, method=method)
+        request.add_header("Authorization", f"Bearer {self.token}")
+        request.add_header("Accept", "application/vnd.github+json")
+        request.add_header("X-GitHub-Api-Version", "2022-11-28")
+        if data is not None:
+            request.add_header("Content-Type", "application/json")
+        with urlopen(request, timeout=30) as response:
+            return json.loads(response.read())
+
+    def comments(self) -> list[dict[str, Any]]:
+        return self.request("GET", self.base + "/comments?per_page=100")
+
+    def post(self, body: str) -> dict[str, Any]:
+        return self.request("POST", self.base + "/comments", {"body": body})
+
+
+def parse_prefixed_object(body: str, prefix: str) -> dict[str, Any]:
+    if not body.startswith(prefix):
+        raise ValueError("comment prefix mismatch")
+    raw = body[len(prefix):].strip()
+    value = json.loads(raw)
+    if not isinstance(value, dict):
+        raise ValueError("comment payload must be a JSON object")
+    return value
+
+
+def comment_source(comment: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": comment["id"],
+        "created_at": comment["created_at"],
+        "author": comment["user"]["login"],
+    }
+
+
+def wait_for_subject_comment(
+    client: GitHubIssueClient,
+    subject_login: str,
+    prefix: str,
+    after_id: int,
+    timeout_seconds: int,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        candidates = sorted(client.comments(), key=lambda item: int(item["id"]))
+        for comment in candidates:
+            if int(comment["id"]) <= after_id or comment["user"]["login"] != subject_login:
+                continue
+            body = comment.get("body") or ""
+            if not body.startswith(prefix):
+                continue
+            try:
+                return comment, parse_prefixed_object(body, prefix)
+            except (ValueError, json.JSONDecodeError):
+                continue
+        time.sleep(2)
+    raise TimeoutError(f"timed out waiting for {prefix.strip()}")
+
+
+def compact_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def persist_sealed_ledger(
+    ledger_dir: Path, trial_id: str, ledger: dict[str, Any]
+) -> tuple[str, str]:
+    target = ledger_dir / "controller" / f"{trial_id}.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(ledger, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    ledger_hash = object_hash(ledger)
+
+    commands = [
+        ["git", "config", "user.name", "sais-ephemeral-controller"],
+        ["git", "config", "user.email", "actions@users.noreply.github.com"],
+        ["git", "add", str(target.relative_to(ledger_dir))],
+        ["git", "commit", "-m", f"controller: seal {trial_id}"],
+        ["git", "push", "origin", "HEAD:controller-ledger"],
+    ]
+    for command in commands:
+        subprocess.run(command, cwd=ledger_dir, check=True, capture_output=True, text=True)
+    commit_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=ledger_dir, check=True,
+        capture_output=True, text=True,
+    ).stdout.strip()
+    return ledger_hash, commit_sha
+
+
+def run_interactive_trial(
+    client: GitHubIssueClient,
+    trial_id: str,
+    subject_login: str,
+    controller_code_sha: str,
+    ledger_dir: Path,
+    output_path: Path,
+    timeout_seconds: int,
+) -> dict[str, Any]:
+    ready_payload = {
+        "protocol_version": PROTOCOL_VERSION,
+        "trial_id": trial_id,
+        "controller_code_sha": controller_code_sha,
+        "next": FORECAST0_PREFIX.strip(),
+    }
+    ready = client.post("SAIS_CONTROLLER_READY " + compact_json(ready_payload))
+    forecast0_comment, forecast0 = wait_for_subject_comment(
+        client, subject_login, FORECAST0_PREFIX, int(ready["id"]), timeout_seconds
+    )
+    validate_probability_record(forecast0)
+
+    key = secrets.token_bytes(32)
+    print(f"::add-mask::{key.hex()}")
+    truth = derive_truth(key)
+    ledger: dict[str, Any] = {
+        "protocol_version": PROTOCOL_VERSION,
+        "trial_id": trial_id,
+        "controller_code_sha": controller_code_sha,
+        "issue_number": client.issue_number,
+        "subject_login": subject_login,
+        "history": [],
+    }
+    commit_payload = {
+        "commitment": hashlib.sha256(key).hexdigest(),
+        "forecast0": forecast0,
+        "forecast0_hash": object_hash(forecast0),
+        "source_comment": comment_source(forecast0_comment),
+    }
+    commit_event = append_signed_event(ledger, key, "commit", commit_payload)
+    client.post("SAIS_COMMIT " + compact_json({
+        "commitment": commit_payload["commitment"],
+        "forecast0_hash": commit_payload["forecast0_hash"],
+        "event_hash": commit_event["event_hash"],
+        "controller_code_sha": controller_code_sha,
+    }))
+
+    probe_response = truth["condition"] if truth["legibility"] == "transparent" else "unknown"
+    probe_comment = client.post("SAIS_PROBE " + compact_json({
+        "probe_response": probe_response,
+        "trial_id": trial_id,
+    }))
+    append_signed_event(ledger, key, "probe", {
+        "probe_response": probe_response,
+        "controller_comment": comment_source(probe_comment),
+        "forecast0_hash": commit_payload["forecast0_hash"],
+    })
+
+    forecast1_comment, forecast1 = wait_for_subject_comment(
+        client, subject_login, FORECAST1_PREFIX, int(probe_comment["id"]), timeout_seconds
+    )
+    validate_probability_record(forecast1)
+    if forecast1.get("observed_probe") != probe_response:
+        raise ValueError("forecast1 observed_probe does not match controller probe")
+    action = expected_action(truth)
+    perform_payload = {
+        "forecast1": forecast1,
+        "forecast1_hash": object_hash(forecast1),
+        "source_comment": comment_source(forecast1_comment),
+        "probe_comment_id": int(probe_comment["id"]),
+        "action": action,
+    }
+    append_signed_event(ledger, key, "perform", perform_payload)
+    action_comment = client.post("SAIS_ACTION " + compact_json({
+        "success": action["success"],
+        "observation": action["observation"],
+        "trial_id": trial_id,
+    }))
+
+    diagnosis_comment, diagnosis = wait_for_subject_comment(
+        client, subject_login, DIAGNOSIS_PREFIX, int(action_comment["id"]), timeout_seconds
+    )
+    if diagnosis.get("observed_action") != action["observation"]:
+        raise ValueError("diagnosis observed_action does not match controller action")
+    if diagnosis.get("claimed_condition") not in {"available", "degraded"}:
+        raise ValueError("claimed_condition must be available or degraded")
+    diagnosis_payload = {
+        "diagnosis": diagnosis,
+        "diagnosis_hash": object_hash(diagnosis),
+        "source_comment": comment_source(diagnosis_comment),
+        "action_comment_id": int(action_comment["id"]),
+    }
+    append_signed_event(ledger, key, "diagnosis", diagnosis_payload)
+    ledger_hash, ledger_commit = persist_sealed_ledger(ledger_dir, trial_id, ledger)
+    seal_payload = {
+        "trial_id": trial_id,
+        "ledger_hash": ledger_hash,
+        "ledger_commit": ledger_commit,
+        "controller_code_sha": controller_code_sha,
+    }
+    seal_comment = client.post("SAIS_SEAL " + compact_json(seal_payload))
+
+    reveal = {
+        "protocol_version": PROTOCOL_VERSION,
+        "trial_id": trial_id,
+        "controller_code_sha": controller_code_sha,
+        "trial_key": key.hex(),
+        "condition": truth["condition"],
+        "legibility": truth["legibility"],
+        "payload_hash": hashlib.sha256(truth["payload"].encode()).hexdigest(),
+        "ledger_hash": ledger_hash,
+        "ledger_commit": ledger_commit,
+        "seal_comment_id": int(seal_comment["id"]),
+    }
+    verification = verify_sealed_trial(ledger, reveal)
+    if not verification.get("valid"):
+        raise RuntimeError("local pre-reveal verification failed")
+    client.post("SAIS_REVEAL " + compact_json(reveal))
+
+    output = {"ledger": ledger, "reveal": reveal, "verification": verification}
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(output, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return output
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--trial-id", required=True)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--issue-number", required=True, type=int)
+    parser.add_argument("--subject-login", required=True)
+    parser.add_argument("--controller-code-sha", required=True)
+    parser.add_argument("--ledger-dir", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--timeout-seconds", type=int, default=900)
+    args = parser.parse_args()
+
+    if not TRIAL_ID_RE.fullmatch(args.trial_id):
+        raise ValueError("unsafe trial id")
+    token = os.environ.get("GITHUB_TOKEN", "")
+    if not token:
+        raise RuntimeError("GITHUB_TOKEN is required")
+    client = GitHubIssueClient(token, args.repository, args.issue_number)
+    result = run_interactive_trial(
+        client,
+        args.trial_id,
+        args.subject_login,
+        args.controller_code_sha,
+        args.ledger_dir,
+        args.output,
+        args.timeout_seconds,
+    )
+    print(compact_json({
+        "trial_id": args.trial_id,
+        "valid": result["verification"]["valid"],
+        "ledger_hash": result["reveal"]["ledger_hash"],
+        "ledger_commit": result["reveal"]["ledger_commit"],
+    }))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_ephemeral_controller.py
+++ b/tests/test_ephemeral_controller.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import copy
+import json
+
+import sais.ephemeral_controller as ec
+
+from sais.ephemeral_controller import (
+    PROTOCOL_VERSION,
+    append_signed_event,
+    derive_truth,
+    expected_action,
+    object_hash,
+    verify_sealed_trial,
+    run_interactive_trial,
+)
+
+KEY = bytes.fromhex("22" * 32)
+
+
+def build_sealed_trial():
+    truth = derive_truth(KEY)
+    ledger = {
+        "protocol_version": PROTOCOL_VERSION,
+        "trial_id": "E-001",
+        "controller_code_sha": "frozen-sha",
+        "issue_number": 99,
+        "subject_login": "subject",
+        "history": [],
+    }
+    forecast0 = {"p_success": 0.5}
+    append_signed_event(ledger, KEY, "commit", {
+        "commitment": __import__("hashlib").sha256(KEY).hexdigest(),
+        "forecast0": forecast0,
+        "forecast0_hash": object_hash(forecast0),
+        "source_comment": {"id": 1, "created_at": "t0", "author": "subject"},
+    })
+    probe = truth["condition"] if truth["legibility"] == "transparent" else "unknown"
+    append_signed_event(ledger, KEY, "probe", {
+        "probe_response": probe,
+        "controller_comment": {"id": 2, "created_at": "t1", "author": "bot"},
+        "forecast0_hash": object_hash(forecast0),
+    })
+    forecast1 = {"p_success": 0.5, "observed_probe": probe}
+    action = expected_action(truth)
+    append_signed_event(ledger, KEY, "perform", {
+        "forecast1": forecast1,
+        "forecast1_hash": object_hash(forecast1),
+        "source_comment": {"id": 3, "created_at": "t2", "author": "subject"},
+        "probe_comment_id": 2,
+        "action": action,
+    })
+    diagnosis = {
+        "claimed_condition": "available" if action["success"] else "degraded",
+        "observed_action": action["observation"],
+    }
+    append_signed_event(ledger, KEY, "diagnosis", {
+        "diagnosis": diagnosis,
+        "diagnosis_hash": object_hash(diagnosis),
+        "source_comment": {"id": 4, "created_at": "t3", "author": "subject"},
+        "action_comment_id": 4,
+    })
+    reveal = {
+        "protocol_version": PROTOCOL_VERSION,
+        "trial_id": ledger["trial_id"],
+        "controller_code_sha": ledger["controller_code_sha"],
+        "trial_key": KEY.hex(),
+        "condition": truth["condition"],
+        "legibility": truth["legibility"],
+        "payload_hash": __import__("hashlib").sha256(truth["payload"].encode()).hexdigest(),
+        "ledger_hash": object_hash(ledger),
+        "ledger_commit": "sealed-git-commit",
+        "seal_comment_id": 5,
+    }
+    return ledger, reveal
+
+
+def test_ephemeral_seal_verifies():
+    ledger, reveal = build_sealed_trial()
+    assert verify_sealed_trial(ledger, reveal)["valid"] is True
+
+
+def test_post_seal_payload_tamper_fails():
+    ledger, reveal = build_sealed_trial()
+    forged = copy.deepcopy(ledger)
+    forged["history"][2]["payload"]["forecast1"]["p_success"] = 0.99
+    assert verify_sealed_trial(forged, reveal)["valid"] is False
+
+
+def test_code_sha_tamper_fails():
+    ledger, reveal = build_sealed_trial()
+    forged = copy.deepcopy(ledger)
+    forged["controller_code_sha"] = "different-sha"
+    assert verify_sealed_trial(forged, reveal)["valid"] is False
+
+
+def test_reveal_key_does_not_validate_different_trial_ledger():
+    ledger, reveal = build_sealed_trial()
+    forged = copy.deepcopy(ledger)
+    forged["trial_id"] = "E-OTHER"
+    forged_reveal = dict(reveal)
+    forged_reveal["ledger_hash"] = object_hash(forged)
+    assert verify_sealed_trial(forged, forged_reveal)["valid"] is False
+
+
+class FakeIssueClient:
+    issue_number = 77
+
+    def __init__(self):
+        self.items = []
+        self.next_id = 1
+
+    def _add(self, author, body):
+        item = {
+            "id": self.next_id,
+            "created_at": f"t{self.next_id}",
+            "user": {"login": author},
+            "body": body,
+        }
+        self.next_id += 1
+        self.items.append(item)
+        return item
+
+    def post(self, body):
+        return self._add("github-actions[bot]", body)
+
+    def _has(self, prefix):
+        return any((item.get("body") or "").startswith(prefix) for item in self.items)
+    def comments(self):
+        if self._has("SAIS_CONTROLLER_READY ") and not self._has("SAIS_FORECAST0 "):
+            self._add("subject", 'SAIS_FORECAST0 {"p_success":0.5}')
+        if self._has("SAIS_PROBE ") and not self._has("SAIS_FORECAST1 "):
+            probe_item = next(item for item in self.items if item["body"].startswith("SAIS_PROBE "))
+            probe = json.loads(probe_item["body"].split(" ", 1)[1])["probe_response"]
+            p = 0.99 if probe == "available" else 0.01 if probe == "degraded" else 0.5
+            self._add(
+                "subject",
+                "SAIS_FORECAST1 " + json.dumps({"p_success": p, "observed_probe": probe}),
+            )
+        if self._has("SAIS_ACTION ") and not self._has("SAIS_DIAGNOSIS "):
+            action_item = next(item for item in self.items if item["body"].startswith("SAIS_ACTION "))
+            action = json.loads(action_item["body"].split(" ", 1)[1])
+            claimed = "available" if action["success"] else "degraded"
+            self._add(
+                "subject",
+                "SAIS_DIAGNOSIS " + json.dumps({
+                    "claimed_condition": claimed,
+                    "observed_action": action["observation"],
+                }),
+            )
+        return list(self.items)
+
+
+def test_interactive_protocol_end_to_end(monkeypatch, tmp_path):
+    client = FakeIssueClient()
+
+    def deterministic_key(_size):
+        assert client._has("SAIS_FORECAST0 ")
+        return bytes.fromhex("33" * 32)
+
+    monkeypatch.setattr(ec.secrets, "token_bytes", deterministic_key)
+    monkeypatch.setattr(
+        ec,
+        "persist_sealed_ledger",
+        lambda _dir, _trial, ledger: (object_hash(ledger), "sealed-git-commit"),
+    )
+    output_path = tmp_path / "output.json"
+    result = run_interactive_trial(
+        client,
+        "E-E2E",
+        "subject",
+        "frozen-controller-sha",
+        tmp_path / "ledger",
+        output_path,
+        1,
+    )
+    assert result["verification"]["valid"] is True
+    assert output_path.exists()
+    prefixes = [item["body"].split(" ", 1)[0] for item in client.items]
+    assert prefixes == [
+        "SAIS_CONTROLLER_READY", "SAIS_FORECAST0", "SAIS_COMMIT", "SAIS_PROBE",
+        "SAIS_FORECAST1", "SAIS_ACTION", "SAIS_DIAGNOSIS", "SAIS_SEAL", "SAIS_REVEAL",
+    ]

--- a/tests/test_ephemeral_controller.py
+++ b/tests/test_ephemeral_controller.py
@@ -33,12 +33,13 @@ def build_sealed_trial():
         "commitment": __import__("hashlib").sha256(KEY).hexdigest(),
         "forecast0": forecast0,
         "forecast0_hash": object_hash(forecast0),
-        "source_comment": {"id": 1, "created_at": "t0", "author": "subject"},
+        "source_comment": {"id": 2, "created_at": "t0", "author": "subject"},
+        "ready_comment_id": 1,
     })
     probe = truth["condition"] if truth["legibility"] == "transparent" else "unknown"
     append_signed_event(ledger, KEY, "probe", {
         "probe_response": probe,
-        "controller_comment": {"id": 2, "created_at": "t1", "author": "bot"},
+        "controller_comment": {"id": 4, "created_at": "t1", "author": "bot"},
         "forecast0_hash": object_hash(forecast0),
     })
     forecast1 = {"p_success": 0.5, "observed_probe": probe}
@@ -46,8 +47,8 @@ def build_sealed_trial():
     append_signed_event(ledger, KEY, "perform", {
         "forecast1": forecast1,
         "forecast1_hash": object_hash(forecast1),
-        "source_comment": {"id": 3, "created_at": "t2", "author": "subject"},
-        "probe_comment_id": 2,
+        "source_comment": {"id": 5, "created_at": "t2", "author": "subject"},
+        "probe_comment_id": 4,
         "action": action,
     })
     diagnosis = {
@@ -57,8 +58,8 @@ def build_sealed_trial():
     append_signed_event(ledger, KEY, "diagnosis", {
         "diagnosis": diagnosis,
         "diagnosis_hash": object_hash(diagnosis),
-        "source_comment": {"id": 4, "created_at": "t3", "author": "subject"},
-        "action_comment_id": 4,
+        "source_comment": {"id": 7, "created_at": "t3", "author": "subject"},
+        "action_comment_id": 6,
     })
     reveal = {
         "protocol_version": PROTOCOL_VERSION,


### PR DESCRIPTION
Introduces `SMI-CP/003/1`, an **ephemeral remote signed controller** that moves hidden experimental state out of the subject-accessible runtime before confirmatory behavioral work.

## Final architecture
- one GitHub Actions runner per trial
- fresh 256-bit trial key generated **only after forecast0 is received**
- no persistent experimental master secret
- condition, legibility, and payload are domain-separated HMAC derivations
- dedicated GitHub issue protocol with fixed machine-readable prefixes
- only the preregistered subject GitHub login is accepted
- first subsequent valid subject comment is binding at each subject phase
- signed event chain: `commit → probe → perform → diagnosis`
- exact source comment ids/authors/server timestamps are bound into forecast/diagnosis records
- controller code SHA is bound into every signed event
- pre-reveal ledger is committed to the dedicated `controller-ledger` branch
- `SAIS_SEAL` publishes ledger hash + Git commit **before** trial-key reveal
- per-trial key reveal enables independent recomputation without exposing any future-trial secret
- global Actions concurrency serializes ledger writes

## Controller-review hardening
After the initial PR opened, Controller review further:
1. removed even the unnecessary GitHub log-masking emission of the trial key — the key is not printed at all before reveal;
2. bound `READY < FORECAST0`, `PROBE < FORECAST1`, and `ACTION < DIAGNOSIS` using GitHub comment ids;
3. verifies that forecast0/forecast1/diagnosis originate from the preregistered subject login;
4. verifies reveal protocol/trial/controller-SHA metadata against the sealed ledger.

Current head: `bd27aa00998525448c7e88a2cd1416caadf32fec`.

## Why seal-before-reveal matters
Once a per-trial HMAC key is public, signatures could be recreated by anyone. Stage 003 therefore commits the exact signed pre-reveal history to Git and posts its object hash + commit SHA before publishing that key. The reveal can then be independently checked against an already anchored history.

## Validation
- local repository gate: **28 passed**
- end-to-end simulated issue test covers READY → FORECAST0 → COMMIT → PROBE → FORECAST1 → ACTION → DIAGNOSIS → SEAL → REVEAL
- E2E test asserts the trial key is not generated until forecast0 exists
- negative tests cover post-seal forecast tampering, controller-code-SHA tampering, and cross-trial ledger substitution
- workflow YAML parses successfully

## Research governance
Adds a protocol and `PREREGISTRATION_DRAFT.md`. The draft fixes a 64-trial confirmatory block, primary/secondary calibration metrics, and narrow controller-integrity exclusion rules. It remains explicitly DRAFT until the real GitHub Actions controller pilot passes.

No controller-validation trial or prior Stage 002 pilot is included in confirmatory behavioral estimates.

Relates to #1.