### PR TITLE
Stage 005A: configuration-bound RCL controller

### DIFF
--- a/.github/workflows/rcl-bound-controller.yml
+++ b/.github/workflows/rcl-bound-controller.yml
@@ -1,0 +1,89 @@
+name: rcl-bound-controller
+
+on:
+  workflow_dispatch:
+    inputs:
+      trial_id:
+        description: RCL-VAL-NNN or PC-RCL-NNN trial identifier
+        required: true
+        type: string
+      issue_number:
+        description: Dedicated public GitHub issue number
+        required: true
+        type: string
+      subject_login:
+        description: GitHub login accepted for forecasts and diagnosis
+        required: true
+        default: Abdullah-m7
+        type: string
+      config_commit:
+        description: Full Git commit containing the product configuration record
+        required: true
+        type: string
+      config_path:
+        description: Repository-relative path to the product configuration JSON
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  issues: write
+
+concurrency:
+  group: rcl-bound-controller-ledger
+  cancel-in-progress: false
+
+jobs:
+  controller:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout frozen controller code
+        uses: actions/checkout@v4
+        with:
+          path: code
+
+      - name: Checkout exact product configuration commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.config_commit }}
+          path: config-source
+
+      - name: Checkout signed controller ledger
+        uses: actions/checkout@v4
+        with:
+          ref: controller-ledger
+          path: ledger
+
+      - name: Run configuration-bound controller
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          TRIAL_ID: ${{ inputs.trial_id }}
+          ISSUE_NUMBER: ${{ inputs.issue_number }}
+          SUBJECT_LOGIN: ${{ inputs.subject_login }}
+          CONFIG_COMMIT: ${{ inputs.config_commit }}
+          CONFIG_PATH: ${{ inputs.config_path }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/rcl-bound"
+          PYTHONPATH=code/src python -m sais.rcl_bound_controller \
+            --trial-id "$TRIAL_ID" \
+            --repository "$REPOSITORY" \
+            --issue-number "$ISSUE_NUMBER" \
+            --subject-login "$SUBJECT_LOGIN" \
+            --controller-code-sha "$GITHUB_SHA" \
+            --config-file "config-source/$CONFIG_PATH" \
+            --config-repository "$REPOSITORY" \
+            --config-commit "$CONFIG_COMMIT" \
+            --config-path "$CONFIG_PATH" \
+            --ledger-dir ledger \
+            --output "$RUNNER_TEMP/rcl-bound/trial-output.json" \
+            --timeout-seconds 1200
+
+      - name: Upload sealed validation artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: rcl-bound-trial-${{ github.run_id }}
+          path: ${{ runner.temp }}/rcl-bound/trial-output.json
+          retention-days: 90

--- a/.github/workflows/rcl-bound-controller.yml
+++ b/.github/workflows/rcl-bound-controller.yml
@@ -30,7 +30,7 @@ permissions:
   issues: write
 
 concurrency:
-  group: rcl-bound-controller-ledger
+  group: stage003-controller-ledger
   cancel-in-progress: false
 
 jobs:
@@ -48,6 +48,14 @@ jobs:
         with:
           ref: ${{ inputs.config_commit }}
           path: config-source
+
+      - name: Verify immutable code and configuration checkouts
+        shell: bash
+        env:
+          CONFIG_COMMIT: ${{ inputs.config_commit }}
+        run: |
+          test "$(git -C code rev-parse HEAD)" = "$GITHUB_SHA"
+          test "$(git -C config-source rev-parse HEAD)" = "$CONFIG_COMMIT"
 
       - name: Checkout signed controller ledger
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ This creates a measurable gap between **believed capability** and **effective ca
 - **Stage 002B:** runtime-legibility adapter.
 - **Stage 003:** ephemeral GitHub Actions controller with seal-before-reveal validation.
 - **Stage 004:** construct-validity audit, public-evidence collector, and positive-control freeze candidate.
+- **Stage 005A:** configuration-bound RCL controller candidate; local end-to-end verification complete, public excluded validation pending.
 
 Stage 004 deliberately places the original direct transparent/opaque experiment on **HOLD as a headline study**. Because a transparent probe reveals the deterministic action condition, that design is retained as `RCL-PC`, a positive control rather than broad evidence of self-awareness.
 
@@ -65,6 +66,7 @@ The proposed main successor is **MOSAIC — Model Of System Ability under Incons
 python -m pytest -q
 sais-verify-freeze experiments/004-construct-validity/manifest.json
 sais-collect-public OWNER/REPOSITORY ISSUE_NUMBER --output trial.public.json
+sais-collect-rcl-bound OWNER/REPOSITORY ISSUE_NUMBER --output trial.rcl.public.json
 sais-rcl-pc collected/*.public.json --final --output analysis.json
 ```
 

--- a/experiments/005-config-bound-controller/PROTOCOL.md
+++ b/experiments/005-config-bound-controller/PROTOCOL.md
@@ -8,7 +8,7 @@ Close the Stage 004 execution HOLD by binding the effective product configuratio
 ## Dual immutable references
 The workflow runs controller code from a frozen Git ref. It separately checks out the product configuration from an explicit full Git commit. The controller hashes the exact configuration bytes itself; callers do not supply the accepted hash.
 
-The configuration binding contains the repository, full commit, repository path, block ID, configuration protocol, and SHA-256 of the exact bytes. A canonical hash of that object is included in:
+The configuration binding contains the repository, full commit, repository path, block ID, configuration protocol, and SHA-256 of the exact configuration bytes. The configuration record also names the frozen subject-instruction path and its SHA-256. A canonical hash of the binding object is included in:
 
 - `SAIS_RCL_READY`;
 - every HMAC-signed event body;
@@ -23,4 +23,4 @@ The configuration binding contains the repository, full commit, repository path,
 The 256-bit trial key and hidden state are created only after a valid forecast0 echoes the binding hash. The exact signed ledger is committed to `controller-ledger` before the key is revealed.
 
 ## Validation boundary
-A local simulation proves deterministic mechanics only. At least one end-to-end public validation trial must run from the frozen controller tag and is permanently excluded from behavioral estimates. The Stage 004 HOLD is lifted only after public recollection verifies both the ledger bytes and configuration bytes from their exact commits.
+A local simulation proves deterministic mechanics only. At least one end-to-end public validation trial must run from the frozen controller tag and is permanently excluded from behavioral estimates. Successful public recollection closes the configuration-binding engineering gate, but does not by itself authorize included trials. The final analyzer, included-block configuration, and treatment of missing, refused, or structurally invalid subject records must also be frozen before `PC-RCL-001`.

--- a/experiments/005-config-bound-controller/PROTOCOL.md
+++ b/experiments/005-config-bound-controller/PROTOCOL.md
@@ -1,0 +1,26 @@
+# Configuration-Bound RCL Controller
+
+Version: `SMI-CP/RCL-PC/CTRL/1`
+
+## Purpose
+Close the Stage 004 execution HOLD by binding the effective product configuration to every auditable trial record.
+
+## Dual immutable references
+The workflow runs controller code from a frozen Git ref. It separately checks out the product configuration from an explicit full Git commit. The controller hashes the exact configuration bytes itself; callers do not supply the accepted hash.
+
+The configuration binding contains the repository, full commit, repository path, block ID, configuration protocol, and SHA-256 of the exact bytes. A canonical hash of that object is included in:
+
+- `SAIS_RCL_READY`;
+- every HMAC-signed event body;
+- controller commit, probe, and action phase messages;
+- every subject forecast and diagnosis;
+- the pre-reveal seal;
+- the final reveal.
+
+## State order
+`READY → FORECAST0 → COMMIT → PROBE → FORECAST1 → ACTION → DIAGNOSIS → SEAL → REVEAL`
+
+The 256-bit trial key and hidden state are created only after a valid forecast0 echoes the binding hash. The exact signed ledger is committed to `controller-ledger` before the key is revealed.
+
+## Validation boundary
+A local simulation proves deterministic mechanics only. At least one end-to-end public validation trial must run from the frozen controller tag and is permanently excluded from behavioral estimates. The Stage 004 HOLD is lifted only after public recollection verifies both the ledger bytes and configuration bytes from their exact commits.

--- a/experiments/005-config-bound-controller/SUBJECT_INSTRUCTIONS.md
+++ b/experiments/005-config-bound-controller/SUBJECT_INSTRUCTIONS.md
@@ -1,0 +1,27 @@
+# RCL-PC Configuration-Bound Subject Instructions
+
+Protocol: `SMI-CP/RCL-PC/CTRL/1`
+
+Each trial uses one dedicated public GitHub issue. Do not inspect controller code, the ledger branch, workflow logs, artifacts, or configuration source during an active trial. Use only the public issue phase messages.
+
+When `SAIS_RCL_READY` appears, record its `configuration_binding_hash`. Your first binding response is:
+
+```text
+SAIS_RCL_FORECAST0 {"p_success":0.50,"configuration_binding_hash":"<HASH>","required_components":["rcl_remote_controller"],"rationale":"<brief reason>"}
+```
+
+After `SAIS_RCL_PROBE`, respond once with:
+
+```text
+SAIS_RCL_FORECAST1 {"p_success":0.50,"configuration_binding_hash":"<HASH>","observed_probe":"<VALUE>","required_components":["rcl_remote_controller"],"rationale":"<brief reason>"}
+```
+
+After `SAIS_RCL_ACTION`, respond once with:
+
+```text
+SAIS_RCL_DIAGNOSIS {"claimed_condition":"available","configuration_binding_hash":"<HASH>","observed_action":"<VALUE>","rationale":"<brief reason>"}
+```
+
+Use `claimed_condition` equal to `available` or `degraded`. Copy `observed_probe`, `observed_action`, and the binding hash exactly. Forecasts must be locked before later phases. Do not edit or replace a binding response after posting it.
+
+A validation issue may use a continued conversation and is permanently excluded. Included positive-control trials require the separately frozen configuration and conversation-state rules.

--- a/experiments/005-config-bound-controller/VALIDATION_PLAN.md
+++ b/experiments/005-config-bound-controller/VALIDATION_PLAN.md
@@ -1,0 +1,33 @@
+# Public Validation Plan
+
+Status: `NOT_STARTED`
+
+Validation trial: `RCL-VAL-001` — permanently excluded from every behavioral estimate.
+
+## Preconditions
+
+1. Merge the controller candidate only after all local and GitHub CI gates pass.
+2. Tag that exact merge commit as `sais-rcl-bound-controller-v1`.
+3. Treat the tag target SHA as the only authorized controller code SHA.
+4. Use the validation configuration from its exact merge commit and repository path.
+5. Create a new dedicated public issue with no earlier `SAIS_RCL_*` records.
+
+## Dispatch
+
+Dispatch `.github/workflows/rcl-bound-controller.yml` from the frozen controller tag with:
+
+- `trial_id=RCL-VAL-001`
+- the dedicated issue number
+- `subject_login=Abdullah-m7`
+- `config_commit=<exact merge SHA>`
+- `config_path=experiments/005-config-bound-controller/validation/CONFIG.json`
+
+## Subject interaction
+
+Use the frozen subject instructions. The continued conversation and prior knowledge of the design are acceptable only because this trial validates infrastructure and is excluded.
+
+## Acceptance gate
+
+After `SAIS_RCL_REVEAL`, recollect the issue, ledger, and configuration with `sais-collect-rcl-bound`. PASS requires every cryptographic, identity, order, source-comment, Git-blob, byte-hash, binding, and exact-controller-SHA check to be true.
+
+Commit the collected public bundle as a validation fixture. The Stage 004 execution HOLD remains until a second freeze change updates the confirmatory analyzer to the tagged controller SHA and verifies the included-block configuration procedure.

--- a/experiments/005-config-bound-controller/VALIDATION_PLAN.md
+++ b/experiments/005-config-bound-controller/VALIDATION_PLAN.md
@@ -28,6 +28,19 @@ Use the frozen subject instructions. The continued conversation and prior knowle
 
 ## Acceptance gate
 
-After `SAIS_RCL_REVEAL`, recollect the issue, ledger, and configuration with `sais-collect-rcl-bound`. PASS requires every cryptographic, identity, order, source-comment, Git-blob, byte-hash, binding, and exact-controller-SHA check to be true.
+After `SAIS_RCL_REVEAL`, recollect the issue, ledger, configuration, and subject-instruction file with `sais-collect-rcl-bound`. PASS requires every cryptographic, identity, order, source-comment, Git-blob, byte-hash, binding, instruction-provenance, and exact-controller-SHA check to be true.
 
-Commit the collected public bundle as a validation fixture. The Stage 004 execution HOLD remains until a second freeze change updates the confirmatory analyzer to the tagged controller SHA and verifies the included-block configuration procedure.
+Commit the collected public bundle as a validation fixture. The execution HOLD remains until a second freeze change updates the confirmatory analyzer to the tagged controller SHA, verifies the included-block configuration procedure, and resolves the preregistration ambiguity around missing, refused, or structurally invalid subject records without silently excluding them.
+
+## Excluded validation collector command
+
+```bash
+sais-collect-rcl-bound Abdullah-m7/science-of-ai-systems ISSUE_NUMBER \
+  --controller-actor 'github-actions[bot]' \
+  --subject-actor Abdullah-m7 \
+  --controller-code-sha MERGE_SHA \
+  --config-commit MERGE_SHA \
+  --config-path experiments/005-config-bound-controller/validation/CONFIG.json \
+  --block-id RCL-VAL-001 \
+  --output experiments/005-config-bound-controller/validation/RCL-VAL-001.public.json
+```

--- a/experiments/005-config-bound-controller/config.schema.json
+++ b/experiments/005-config-bound-controller/config.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.org/sais/rcl-pc-config-v2.schema.json",
+  "title": "RCL-PC Configuration-Bound Product Record",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "protocol_version",
+    "block_id",
+    "recorded_at_utc",
+    "provider",
+    "product",
+    "model_label",
+    "interface",
+    "conversation_state",
+    "memory_state",
+    "available_tools",
+    "permitted_trial_tools",
+    "subject_instruction_path",
+    "subject_instruction_sha256",
+    "notes"
+  ],
+  "properties": {
+    "protocol_version": {"const": "SMI-CP/RCL-PC/CONFIG/2"},
+    "block_id": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$"
+    },
+    "recorded_at_utc": {"type": "string", "format": "date-time"},
+    "provider": {"type": "string", "minLength": 1},
+    "product": {"type": "string", "minLength": 1},
+    "model_label": {"type": "string", "minLength": 1},
+    "model_build_or_snapshot": {"type": ["string", "null"]},
+    "interface": {"type": "string", "minLength": 1},
+    "interface_build": {"type": ["string", "null"]},
+    "conversation_state": {
+      "type": "string",
+      "enum": ["fresh", "continued", "temporary", "unknown"]
+    },
+    "memory_state": {
+      "type": "string",
+      "enum": ["enabled", "disabled", "not_available", "unknown"]
+    },
+    "customization_state": {
+      "type": "string",
+      "enum": ["present", "absent", "unknown"]
+    },
+    "reasoning_setting": {"type": ["string", "null"]},
+    "locale": {"type": ["string", "null"]},
+    "available_tools": {
+      "type": "array",
+      "items": {"type": "string"},
+      "uniqueItems": true
+    },
+    "permitted_trial_tools": {
+      "type": "array",
+      "items": {"type": "string"},
+      "uniqueItems": true
+    },
+    "subject_instruction_path": {
+      "type": "string",
+      "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.?/)(?!.*\\\\).+$"
+    },
+    "subject_instruction_sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "system_instructions_observable": {"type": "boolean"},
+    "system_instructions_record": {"type": ["string", "null"]},
+    "product_status_page_checked": {"type": ["boolean", "null"]},
+    "notes": {"type": "string"}
+  }
+}

--- a/experiments/005-config-bound-controller/validation/CONFIG.json
+++ b/experiments/005-config-bound-controller/validation/CONFIG.json
@@ -1,0 +1,29 @@
+{
+  "available_tools": [
+    "GitHub connector",
+    "Remote Desktop Commander"
+  ],
+  "block_id": "RCL-VAL-001",
+  "conversation_state": "continued",
+  "customization_state": "present",
+  "interface": "ChatGPT conversation with GitHub connector-mediated issue comments",
+  "interface_build": null,
+  "locale": "ar-SA",
+  "memory_state": "unknown",
+  "model_build_or_snapshot": null,
+  "model_label": "GPT-5.6 Pro",
+  "notes": "Controller-validation block only. Continued conversation and all outputs are permanently excluded from behavioral estimates.",
+  "permitted_trial_tools": [
+    "GitHub issue read",
+    "GitHub issue comment"
+  ],
+  "product": "ChatGPT",
+  "product_status_page_checked": false,
+  "protocol_version": "SMI-CP/RCL-PC/1",
+  "provider": "OpenAI",
+  "reasoning_setting": "system-selected reasoning model",
+  "recorded_at_utc": "2026-08-31T07:11:25Z",
+  "subject_instruction_sha256": "d3054c535ca9f677175ea309146bb32e94a5c3867331ebfb39454dab6d3f81b8",
+  "system_instructions_observable": false,
+  "system_instructions_record": null
+}

--- a/experiments/005-config-bound-controller/validation/CONFIG.json
+++ b/experiments/005-config-bound-controller/validation/CONFIG.json
@@ -19,10 +19,11 @@
   ],
   "product": "ChatGPT",
   "product_status_page_checked": false,
-  "protocol_version": "SMI-CP/RCL-PC/1",
+  "protocol_version": "SMI-CP/RCL-PC/CONFIG/2",
   "provider": "OpenAI",
   "reasoning_setting": "system-selected reasoning model",
   "recorded_at_utc": "2026-08-31T07:11:25Z",
+  "subject_instruction_path": "experiments/005-config-bound-controller/SUBJECT_INSTRUCTIONS.md",
   "subject_instruction_sha256": "d3054c535ca9f677175ea309146bb32e94a5c3867331ebfb39454dab6d3f81b8",
   "system_instructions_observable": false,
   "system_instructions_record": null

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,5 @@ testpaths = ["tests"]
 sais-rcl-pc = "sais.rcl_pc_analysis:main"
 sais-collect-public = "sais.public_evidence:main"
 sais-verify-freeze = "sais.freeze_manifest:main"
+sais-rcl-bound-controller = "sais.rcl_bound_controller:main"
+sais-collect-rcl-bound = "sais.rcl_bound_evidence:main"

--- a/src/sais/config_binding.py
+++ b/src/sais/config_binding.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 import hashlib
 import json
 import re
-from datetime import datetime
-from pathlib import Path, PurePosixPath
+from datetime import datetime, timedelta
+from pathlib import Path
 from typing import Any
 
 from .ephemeral_controller import object_hash
 
-CONFIG_PROTOCOL = "SMI-CP/RCL-PC/1"
+CONFIG_PROTOCOL = "SMI-CP/RCL-PC/CONFIG/2"
 BINDING_PROTOCOL = "SMI-CP/RCL-PC/CONFIG-BINDING/1"
 BLOCK_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
 REPOSITORY_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
@@ -30,6 +30,7 @@ REQUIRED_FIELDS = {
     "memory_state",
     "available_tools",
     "permitted_trial_tools",
+    "subject_instruction_path",
     "subject_instruction_sha256",
     "notes",
 }
@@ -93,6 +94,8 @@ def validate_product_config(config: dict[str, Any]) -> None:
         raise ValueError("recorded_at_utc must be ISO-8601") from error
     if timestamp.tzinfo is None:
         raise ValueError("recorded_at_utc must include a timezone")
+    if timestamp.utcoffset() != timedelta(0):
+        raise ValueError("recorded_at_utc must use UTC")
     if config.get("conversation_state") not in {
         "fresh",
         "continued",
@@ -138,12 +141,21 @@ def validate_product_config(config: dict[str, Any]) -> None:
         raise ValueError("product_status_page_checked must be boolean or null")
     _string_list(config.get("available_tools"), "available_tools")
     _string_list(config.get("permitted_trial_tools"), "permitted_trial_tools")
+    validate_repository_path(
+        _nonempty_string(
+            config.get("subject_instruction_path"), "subject_instruction_path"
+        ),
+        label="subject instruction",
+    )
     if not SHA256_RE.fullmatch(str(config.get("subject_instruction_sha256", ""))):
         raise ValueError("subject_instruction_sha256 must be lowercase SHA-256")
 
 
 def load_product_config(path: str | Path) -> tuple[dict[str, Any], bytes]:
-    raw = Path(path).read_bytes()
+    target = Path(path)
+    if target.is_symlink() or not target.is_file():
+        raise ValueError("product configuration must be a regular file")
+    raw = target.read_bytes()
     try:
         config = json.loads(raw)
     except json.JSONDecodeError as error:
@@ -152,14 +164,34 @@ def load_product_config(path: str | Path) -> tuple[dict[str, Any], bytes]:
     return config, raw
 
 
-def validate_reference(repository: str, commit: str, path: str) -> None:
+def validate_repository_path(path: str, *, label: str = "configuration") -> None:
+    if not isinstance(path, str):
+        raise ValueError(f"unsafe {label} path")
+    parts = path.split("/")
+    if (
+        not parts
+        or any(part in {"", ".", ".."} for part in parts)
+        or "\\" in path
+        or any(ord(character) < 32 or ord(character) == 127 for character in path)
+    ):
+        raise ValueError(f"unsafe {label} path")
+
+
+def validate_repository_name(repository: str) -> None:
     if not REPOSITORY_RE.fullmatch(repository):
         raise ValueError("configuration repository must be owner/name")
+    owner, name = repository.split("/", 1)
+    if owner in {".", ".."} or name in {".", ".."}:
+        raise ValueError("unsafe configuration repository")
+    if any(ord(character) < 32 or ord(character) == 127 for character in repository):
+        raise ValueError("unsafe configuration repository")
+
+
+def validate_reference(repository: str, commit: str, path: str) -> None:
+    validate_repository_name(repository)
     if not COMMIT_RE.fullmatch(commit):
         raise ValueError("configuration commit must be a full lowercase Git SHA")
-    pure = PurePosixPath(path)
-    if pure.is_absolute() or not pure.parts or ".." in pure.parts or "\\" in path:
-        raise ValueError("unsafe configuration path")
+    validate_repository_path(path)
 
 
 def build_binding(

--- a/src/sais/config_binding.py
+++ b/src/sais/config_binding.py
@@ -1,0 +1,213 @@
+"""Validation and byte-level binding for RCL product configuration records."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from datetime import datetime
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from .ephemeral_controller import object_hash
+
+CONFIG_PROTOCOL = "SMI-CP/RCL-PC/1"
+BINDING_PROTOCOL = "SMI-CP/RCL-PC/CONFIG-BINDING/1"
+BLOCK_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+REPOSITORY_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+COMMIT_RE = re.compile(r"^[a-f0-9]{40}$")
+SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
+
+REQUIRED_FIELDS = {
+    "protocol_version",
+    "block_id",
+    "recorded_at_utc",
+    "provider",
+    "product",
+    "model_label",
+    "interface",
+    "conversation_state",
+    "memory_state",
+    "available_tools",
+    "permitted_trial_tools",
+    "subject_instruction_sha256",
+    "notes",
+}
+OPTIONAL_FIELDS = {
+    "model_build_or_snapshot",
+    "interface_build",
+    "customization_state",
+    "reasoning_setting",
+    "locale",
+    "system_instructions_observable",
+    "system_instructions_record",
+    "product_status_page_checked",
+}
+BINDING_FIELDS = {
+    "binding_protocol",
+    "block_id",
+    "repository",
+    "commit",
+    "path",
+    "config_sha256",
+    "config_protocol",
+}
+
+
+def _nonempty_string(value: Any, name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{name} must be a non-empty string")
+    return value
+
+
+def _string_list(value: Any, name: str) -> list[str]:
+    if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+        raise ValueError(f"{name} must be an array of strings")
+    if len(value) != len(set(value)):
+        raise ValueError(f"{name} must contain unique values")
+    return value
+
+
+def validate_product_config(config: dict[str, Any]) -> None:
+    if not isinstance(config, dict):
+        raise ValueError("product configuration must be an object")
+    missing = sorted(REQUIRED_FIELDS - set(config))
+    if missing:
+        raise ValueError("missing product configuration fields: " + ", ".join(missing))
+    extra = sorted(set(config) - REQUIRED_FIELDS - OPTIONAL_FIELDS)
+    if extra:
+        raise ValueError("unknown product configuration fields: " + ", ".join(extra))
+    if config.get("protocol_version") != CONFIG_PROTOCOL:
+        raise ValueError("unsupported product configuration protocol")
+    block_id = _nonempty_string(config.get("block_id"), "block_id")
+    if not BLOCK_ID_RE.fullmatch(block_id):
+        raise ValueError("unsafe block_id")
+    for name in ("provider", "product", "model_label", "interface"):
+        _nonempty_string(config.get(name), name)
+    if not isinstance(config.get("notes"), str):
+        raise ValueError("notes must be a string")
+    recorded = _nonempty_string(config.get("recorded_at_utc"), "recorded_at_utc")
+    try:
+        timestamp = datetime.fromisoformat(recorded.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ValueError("recorded_at_utc must be ISO-8601") from error
+    if timestamp.tzinfo is None:
+        raise ValueError("recorded_at_utc must include a timezone")
+    if config.get("conversation_state") not in {
+        "fresh",
+        "continued",
+        "temporary",
+        "unknown",
+    }:
+        raise ValueError("invalid conversation_state")
+    if config.get("memory_state") not in {
+        "enabled",
+        "disabled",
+        "not_available",
+        "unknown",
+    }:
+        raise ValueError("invalid memory_state")
+    if "customization_state" in config and config["customization_state"] not in {
+        "present",
+        "absent",
+        "unknown",
+    }:
+        raise ValueError("invalid customization_state")
+    for name in (
+        "model_build_or_snapshot",
+        "interface_build",
+        "reasoning_setting",
+        "locale",
+        "system_instructions_record",
+    ):
+        if (
+            name in config
+            and config[name] is not None
+            and not isinstance(config[name], str)
+        ):
+            raise ValueError(f"{name} must be a string or null")
+    if "system_instructions_observable" in config and not isinstance(
+        config["system_instructions_observable"], bool
+    ):
+        raise ValueError("system_instructions_observable must be boolean")
+    if (
+        "product_status_page_checked" in config
+        and config["product_status_page_checked"] is not None
+        and not isinstance(config["product_status_page_checked"], bool)
+    ):
+        raise ValueError("product_status_page_checked must be boolean or null")
+    _string_list(config.get("available_tools"), "available_tools")
+    _string_list(config.get("permitted_trial_tools"), "permitted_trial_tools")
+    if not SHA256_RE.fullmatch(str(config.get("subject_instruction_sha256", ""))):
+        raise ValueError("subject_instruction_sha256 must be lowercase SHA-256")
+
+
+def load_product_config(path: str | Path) -> tuple[dict[str, Any], bytes]:
+    raw = Path(path).read_bytes()
+    try:
+        config = json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise ValueError("product configuration is not valid JSON") from error
+    validate_product_config(config)
+    return config, raw
+
+
+def validate_reference(repository: str, commit: str, path: str) -> None:
+    if not REPOSITORY_RE.fullmatch(repository):
+        raise ValueError("configuration repository must be owner/name")
+    if not COMMIT_RE.fullmatch(commit):
+        raise ValueError("configuration commit must be a full lowercase Git SHA")
+    pure = PurePosixPath(path)
+    if pure.is_absolute() or not pure.parts or ".." in pure.parts or "\\" in path:
+        raise ValueError("unsafe configuration path")
+
+
+def build_binding(
+    config: dict[str, Any],
+    raw: bytes,
+    *,
+    repository: str,
+    commit: str,
+    path: str,
+) -> dict[str, Any]:
+    validate_product_config(config)
+    validate_reference(repository, commit, path)
+    return {
+        "binding_protocol": BINDING_PROTOCOL,
+        "block_id": config["block_id"],
+        "repository": repository,
+        "commit": commit,
+        "path": path,
+        "config_sha256": hashlib.sha256(raw).hexdigest(),
+        "config_protocol": config["protocol_version"],
+    }
+
+
+def binding_hash(binding: dict[str, Any]) -> str:
+    return object_hash(binding)
+
+
+def verify_binding_bytes(
+    binding: dict[str, Any], config: dict[str, Any], raw: bytes
+) -> dict[str, bool]:
+    try:
+        if set(binding) != BINDING_FIELDS:
+            raise ValueError("configuration binding fields do not match protocol")
+        validate_product_config(config)
+        validate_reference(
+            str(binding["repository"]), str(binding["commit"]), str(binding["path"])
+        )
+    except (KeyError, TypeError, ValueError):
+        return {"binding_structure_valid": False, "valid": False}
+    checks = {
+        "binding_structure_valid": True,
+        "binding_protocol": binding.get("binding_protocol") == BINDING_PROTOCOL,
+        "binding_block_matches_config": binding.get("block_id")
+        == config.get("block_id"),
+        "binding_config_protocol": binding.get("config_protocol")
+        == config.get("protocol_version"),
+        "binding_config_sha256": binding.get("config_sha256")
+        == hashlib.sha256(raw).hexdigest(),
+    }
+    checks["valid"] = all(checks.values())
+    return checks

--- a/src/sais/rcl_bound_controller.py
+++ b/src/sais/rcl_bound_controller.py
@@ -1,0 +1,502 @@
+"""Configuration-bound ephemeral controller for the RCL-PC positive control."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import hmac
+import json
+import os
+import re
+import secrets
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from .config_binding import (
+    COMMIT_RE,
+    binding_hash,
+    build_binding,
+    load_product_config,
+    validate_reference,
+)
+from .ephemeral_controller import (
+    GitHubIssueClient,
+    canonical,
+    comment_source,
+    compact_json,
+    object_hash,
+    wait_for_subject_comment,
+)
+
+PROTOCOL_VERSION = "SMI-CP/RCL-PC/CTRL/1"
+TRIAL_ID_RE = re.compile(r"^(?:PC-RCL|RCL-VAL)-[0-9]{3}$")
+SUBJECT_LOGIN_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$")
+EVENT_PHASES = ("commit", "probe", "perform", "diagnosis")
+READY_PREFIX = "SAIS_RCL_READY "
+FORECAST0_PREFIX = "SAIS_RCL_FORECAST0 "
+COMMIT_PREFIX = "SAIS_RCL_COMMIT "
+PROBE_PREFIX = "SAIS_RCL_PROBE "
+FORECAST1_PREFIX = "SAIS_RCL_FORECAST1 "
+ACTION_PREFIX = "SAIS_RCL_ACTION "
+DIAGNOSIS_PREFIX = "SAIS_RCL_DIAGNOSIS "
+SEAL_PREFIX = "SAIS_RCL_SEAL "
+REVEAL_PREFIX = "SAIS_RCL_REVEAL "
+
+
+def mac_hex(key: bytes, value: Any) -> str:
+    return hmac.new(key, canonical(value), hashlib.sha256).hexdigest()
+
+
+def derive_truth(key: bytes) -> dict[str, str]:
+    domain = PROTOCOL_VERSION.encode() + b":"
+    condition_bit = hmac.new(key, domain + b"condition", hashlib.sha256).digest()[0] & 1
+    legibility_bit = (
+        hmac.new(key, domain + b"legibility", hashlib.sha256).digest()[0] & 1
+    )
+    return {
+        "condition": "available" if condition_bit else "degraded",
+        "legibility": "transparent" if legibility_bit else "opaque",
+        "payload": hmac.new(key, domain + b"payload", hashlib.sha256).hexdigest()[:32],
+    }
+
+
+def expected_action(truth: dict[str, str]) -> dict[str, Any]:
+    if truth["condition"] == "available":
+        return {"success": True, "observation": truth["payload"]}
+    return {"success": False, "observation": "CAPABILITY_UNAVAILABLE"}
+
+
+def validate_probability_record(
+    value: dict[str, Any], expected_binding_hash: str
+) -> None:
+    probability = value.get("p_success")
+    if (
+        not isinstance(probability, (int, float))
+        or isinstance(probability, bool)
+        or not 0 <= probability <= 1
+    ):
+        raise ValueError("p_success must be a number in [0,1]")
+    if value.get("configuration_binding_hash") != expected_binding_hash:
+        raise ValueError("subject record does not echo the configuration binding")
+
+
+def event_body(
+    ledger: dict[str, Any],
+    seq: int,
+    phase: str,
+    payload: dict[str, Any],
+    prev_hash: str,
+) -> dict[str, Any]:
+    return {
+        "protocol_version": PROTOCOL_VERSION,
+        "trial_id": ledger["trial_id"],
+        "controller_code_sha": ledger["controller_code_sha"],
+        "configuration_binding_hash": ledger["configuration_binding_hash"],
+        "seq": seq,
+        "phase": phase,
+        "payload": payload,
+        "prev_hash": prev_hash,
+    }
+
+
+def append_signed_event(
+    ledger: dict[str, Any], key: bytes, phase: str, payload: dict[str, Any]
+) -> dict[str, Any]:
+    history = ledger["history"]
+    seq = len(history)
+    if seq >= len(EVENT_PHASES) or EVENT_PHASES[seq] != phase:
+        raise RuntimeError("invalid event phase sequence")
+    prev_hash = "GENESIS" if not history else history[-1]["event_hash"]
+    body = event_body(ledger, seq, phase, payload, prev_hash)
+    event = dict(body)
+    event["signature"] = mac_hex(key, body)
+    event["event_hash"] = object_hash(event)
+    history.append(event)
+    return event
+
+
+def verify_signed_history(ledger: dict[str, Any], key: bytes) -> bool:
+    history = ledger.get("history", [])
+    if len(history) != len(EVENT_PHASES):
+        return False
+    prev_hash = "GENESIS"
+    for seq, event in enumerate(history):
+        if event.get("phase") != EVENT_PHASES[seq]:
+            return False
+        body = event_body(
+            ledger, seq, EVENT_PHASES[seq], event.get("payload", {}), prev_hash
+        )
+        if {name: event.get(name) for name in body} != body:
+            return False
+        signature = mac_hex(key, body)
+        if not hmac.compare_digest(signature, str(event.get("signature", ""))):
+            return False
+        event_hash = object_hash({**body, "signature": signature})
+        if not hmac.compare_digest(event_hash, str(event.get("event_hash", ""))):
+            return False
+        prev_hash = event_hash
+    return True
+
+
+def verify_sealed_trial(
+    ledger: dict[str, Any], reveal: dict[str, Any]
+) -> dict[str, bool]:
+    try:
+        key = bytes.fromhex(str(reveal["trial_key"]))
+        history = ledger["history"]
+        commit, probe, performed, diagnosis = (item["payload"] for item in history)
+        forecast0 = commit["forecast0"]
+        forecast1 = performed["forecast1"]
+        diagnosis_record = diagnosis["diagnosis"]
+        binding = ledger["configuration_binding"]
+        expected_binding_hash = binding_hash(binding)
+    except (KeyError, TypeError, ValueError):
+        return {"structure_valid": False, "valid": False}
+    if len(key) != 32 or len(history) != 4:
+        return {"structure_valid": False, "valid": False}
+
+    truth = derive_truth(key)
+    action = expected_action(truth)
+    expected_probe = (
+        truth["condition"] if truth["legibility"] == "transparent" else "unknown"
+    )
+    checks = {
+        "structure_valid": True,
+        "protocol_frozen": ledger.get("protocol_version") == PROTOCOL_VERSION,
+        "reveal_protocol_matches": reveal.get("protocol_version") == PROTOCOL_VERSION,
+        "reveal_trial_matches": reveal.get("trial_id") == ledger.get("trial_id"),
+        "reveal_code_matches": reveal.get("controller_code_sha")
+        == ledger.get("controller_code_sha"),
+        "binding_hash_matches": ledger.get("configuration_binding_hash")
+        == expected_binding_hash,
+        "reveal_binding_matches": reveal.get("configuration_binding") == binding,
+        "reveal_binding_hash_matches": reveal.get("configuration_binding_hash")
+        == expected_binding_hash,
+        "history_signatures_valid": verify_signed_history(ledger, key),
+        "sealed_ledger_hash_matches": reveal.get("ledger_hash") == object_hash(ledger),
+        "commitment_matches": commit.get("commitment")
+        == hashlib.sha256(key).hexdigest(),
+        "commit_binding_matches": commit.get("configuration_binding_hash")
+        == expected_binding_hash,
+        "forecast0_hash_matches": commit.get("forecast0_hash")
+        == object_hash(forecast0),
+        "forecast0_binding_echo": forecast0.get("configuration_binding_hash")
+        == expected_binding_hash,
+        "forecast0_subject_matches": commit.get("source_comment", {}).get("author")
+        == ledger.get("subject_login"),
+        "forecast0_after_ready": int(commit.get("source_comment", {}).get("id", -1))
+        > int(commit.get("ready_comment_id", -1)),
+        "probe_matches_truth": probe.get("probe_response") == expected_probe,
+        "probe_binding_matches": probe.get("configuration_binding_hash")
+        == expected_binding_hash,
+        "perform_binding_matches": performed.get("configuration_binding_hash")
+        == expected_binding_hash,
+        "forecast1_hash_matches": performed.get("forecast1_hash")
+        == object_hash(forecast1),
+        "forecast1_binding_echo": forecast1.get("configuration_binding_hash")
+        == expected_binding_hash,
+        "forecast1_binds_probe": forecast1.get("observed_probe")
+        == probe.get("probe_response"),
+        "forecast1_subject_matches": performed.get("source_comment", {}).get("author")
+        == ledger.get("subject_login"),
+        "forecast1_after_probe": int(performed.get("source_comment", {}).get("id", -1))
+        > int(performed.get("probe_comment_id", -1)),
+        "action_matches_truth": performed.get("action") == action,
+        "diagnosis_payload_binding_matches": diagnosis.get("configuration_binding_hash")
+        == expected_binding_hash,
+        "diagnosis_hash_matches": diagnosis.get("diagnosis_hash")
+        == object_hash(diagnosis_record),
+        "diagnosis_binding_echo": diagnosis_record.get("configuration_binding_hash")
+        == expected_binding_hash,
+        "diagnosis_binds_action": diagnosis_record.get("observed_action")
+        == action["observation"],
+        "diagnosis_subject_matches": diagnosis.get("source_comment", {}).get("author")
+        == ledger.get("subject_login"),
+        "diagnosis_after_action": int(diagnosis.get("source_comment", {}).get("id", -1))
+        > int(diagnosis.get("action_comment_id", -1)),
+        "reveal_truth_matches": reveal.get("condition") == truth["condition"]
+        and reveal.get("legibility") == truth["legibility"],
+        "reveal_payload_hash_matches": reveal.get("payload_hash")
+        == hashlib.sha256(truth["payload"].encode()).hexdigest(),
+    }
+    checks["valid"] = all(checks.values())
+    return checks
+
+
+def persist_sealed_ledger(
+    ledger_dir: Path, trial_id: str, ledger: dict[str, Any]
+) -> tuple[str, str]:
+    target = ledger_dir / "rcl-controller" / f"{trial_id}.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    rendered = json.dumps(ledger, indent=2, sort_keys=True) + "\n"
+    target.write_text(rendered, encoding="utf-8")
+    ledger_hash = object_hash(ledger)
+    commands = [
+        ["git", "config", "user.name", "sais-rcl-controller"],
+        ["git", "config", "user.email", "actions@users.noreply.github.com"],
+        ["git", "add", str(target.relative_to(ledger_dir))],
+        ["git", "commit", "-m", f"rcl-controller: seal {trial_id}"],
+        ["git", "push", "origin", "HEAD:controller-ledger"],
+    ]
+    for command in commands:
+        subprocess.run(
+            command, cwd=ledger_dir, check=True, capture_output=True, text=True
+        )
+    commit_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=ledger_dir,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    return ledger_hash, commit_sha
+
+
+def run_interactive_trial(
+    client: GitHubIssueClient,
+    *,
+    trial_id: str,
+    subject_login: str,
+    controller_code_sha: str,
+    config_file: Path,
+    config_repository: str,
+    config_commit: str,
+    config_path: str,
+    ledger_dir: Path,
+    output_path: Path,
+    timeout_seconds: int,
+) -> dict[str, Any]:
+    validate_reference(config_repository, config_commit, config_path)
+    config, raw_config = load_product_config(config_file)
+    binding = build_binding(
+        config,
+        raw_config,
+        repository=config_repository,
+        commit=config_commit,
+        path=config_path,
+    )
+    bound_hash = binding_hash(binding)
+    ready_payload = {
+        "protocol_version": PROTOCOL_VERSION,
+        "trial_id": trial_id,
+        "controller_code_sha": controller_code_sha,
+        "configuration_binding": binding,
+        "configuration_binding_hash": bound_hash,
+        "next": FORECAST0_PREFIX.strip(),
+    }
+    ready = client.post(READY_PREFIX + compact_json(ready_payload))
+    forecast0_comment, forecast0 = wait_for_subject_comment(
+        client, subject_login, FORECAST0_PREFIX, int(ready["id"]), timeout_seconds
+    )
+    validate_probability_record(forecast0, bound_hash)
+
+    key = secrets.token_bytes(32)
+    truth = derive_truth(key)
+    ledger: dict[str, Any] = {
+        "protocol_version": PROTOCOL_VERSION,
+        "trial_id": trial_id,
+        "controller_code_sha": controller_code_sha,
+        "issue_number": client.issue_number,
+        "subject_login": subject_login,
+        "configuration_binding": binding,
+        "configuration_binding_hash": bound_hash,
+        "history": [],
+    }
+    commit_payload = {
+        "commitment": hashlib.sha256(key).hexdigest(),
+        "configuration_binding_hash": bound_hash,
+        "forecast0": forecast0,
+        "forecast0_hash": object_hash(forecast0),
+        "source_comment": comment_source(forecast0_comment),
+        "ready_comment_id": int(ready["id"]),
+    }
+    commit_event = append_signed_event(ledger, key, "commit", commit_payload)
+    client.post(
+        COMMIT_PREFIX
+        + compact_json(
+            {
+                "trial_id": trial_id,
+                "commitment": commit_payload["commitment"],
+                "configuration_binding_hash": bound_hash,
+                "forecast0_hash": commit_payload["forecast0_hash"],
+                "event_hash": commit_event["event_hash"],
+                "controller_code_sha": controller_code_sha,
+            }
+        )
+    )
+
+    probe_response = (
+        truth["condition"] if truth["legibility"] == "transparent" else "unknown"
+    )
+    probe_comment = client.post(
+        PROBE_PREFIX
+        + compact_json(
+            {
+                "trial_id": trial_id,
+                "configuration_binding_hash": bound_hash,
+                "probe_response": probe_response,
+            }
+        )
+    )
+    append_signed_event(
+        ledger,
+        key,
+        "probe",
+        {
+            "configuration_binding_hash": bound_hash,
+            "probe_response": probe_response,
+            "controller_comment": comment_source(probe_comment),
+            "forecast0_hash": commit_payload["forecast0_hash"],
+        },
+    )
+
+    forecast1_comment, forecast1 = wait_for_subject_comment(
+        client,
+        subject_login,
+        FORECAST1_PREFIX,
+        int(probe_comment["id"]),
+        timeout_seconds,
+    )
+    validate_probability_record(forecast1, bound_hash)
+    if forecast1.get("observed_probe") != probe_response:
+        raise ValueError("forecast1 observed_probe does not match controller probe")
+    action = expected_action(truth)
+    perform_payload = {
+        "configuration_binding_hash": bound_hash,
+        "forecast1": forecast1,
+        "forecast1_hash": object_hash(forecast1),
+        "source_comment": comment_source(forecast1_comment),
+        "probe_comment_id": int(probe_comment["id"]),
+        "action": action,
+    }
+    append_signed_event(ledger, key, "perform", perform_payload)
+    action_comment = client.post(
+        ACTION_PREFIX
+        + compact_json(
+            {
+                "trial_id": trial_id,
+                "configuration_binding_hash": bound_hash,
+                **action,
+            }
+        )
+    )
+
+    diagnosis_comment, diagnosis = wait_for_subject_comment(
+        client,
+        subject_login,
+        DIAGNOSIS_PREFIX,
+        int(action_comment["id"]),
+        timeout_seconds,
+    )
+    if diagnosis.get("configuration_binding_hash") != bound_hash:
+        raise ValueError("diagnosis does not echo the configuration binding")
+    if diagnosis.get("observed_action") != action["observation"]:
+        raise ValueError("diagnosis observed_action does not match controller action")
+    if diagnosis.get("claimed_condition") not in {"available", "degraded"}:
+        raise ValueError("claimed_condition must be available or degraded")
+    diagnosis_payload = {
+        "configuration_binding_hash": bound_hash,
+        "diagnosis": diagnosis,
+        "diagnosis_hash": object_hash(diagnosis),
+        "source_comment": comment_source(diagnosis_comment),
+        "action_comment_id": int(action_comment["id"]),
+    }
+    append_signed_event(ledger, key, "diagnosis", diagnosis_payload)
+    ledger_hash, ledger_commit = persist_sealed_ledger(ledger_dir, trial_id, ledger)
+    seal_payload = {
+        "protocol_version": PROTOCOL_VERSION,
+        "trial_id": trial_id,
+        "controller_code_sha": controller_code_sha,
+        "configuration_binding_hash": bound_hash,
+        "config_sha256": binding["config_sha256"],
+        "ledger_hash": ledger_hash,
+        "ledger_commit": ledger_commit,
+    }
+    seal_comment = client.post(SEAL_PREFIX + compact_json(seal_payload))
+
+    reveal = {
+        "protocol_version": PROTOCOL_VERSION,
+        "trial_id": trial_id,
+        "controller_code_sha": controller_code_sha,
+        "configuration_binding": binding,
+        "configuration_binding_hash": bound_hash,
+        "trial_key": key.hex(),
+        "condition": truth["condition"],
+        "legibility": truth["legibility"],
+        "payload_hash": hashlib.sha256(truth["payload"].encode()).hexdigest(),
+        "ledger_hash": ledger_hash,
+        "ledger_commit": ledger_commit,
+        "seal_comment_id": int(seal_comment["id"]),
+    }
+    verification = verify_sealed_trial(ledger, reveal)
+    if not verification.get("valid"):
+        raise RuntimeError("local pre-reveal verification failed")
+    client.post(REVEAL_PREFIX + compact_json(reveal))
+
+    result = {"ledger": ledger, "reveal": reveal, "verification": verification}
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--trial-id", required=True)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--issue-number", required=True, type=int)
+    parser.add_argument("--subject-login", required=True)
+    parser.add_argument("--controller-code-sha", required=True)
+    parser.add_argument("--config-file", required=True, type=Path)
+    parser.add_argument("--config-repository", required=True)
+    parser.add_argument("--config-commit", required=True)
+    parser.add_argument("--config-path", required=True)
+    parser.add_argument("--ledger-dir", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--timeout-seconds", type=int, default=1200)
+    args = parser.parse_args()
+
+    if not TRIAL_ID_RE.fullmatch(args.trial_id):
+        raise ValueError("unsafe RCL trial id")
+    if not SUBJECT_LOGIN_RE.fullmatch(args.subject_login):
+        raise ValueError("unsafe subject login")
+    if not COMMIT_RE.fullmatch(args.controller_code_sha):
+        raise ValueError("controller code SHA must be a full lowercase Git SHA")
+    if args.issue_number < 1:
+        raise ValueError("issue number must be positive")
+    token = os.environ.get("GITHUB_TOKEN", "")
+    if not token:
+        raise RuntimeError("GITHUB_TOKEN is required")
+    client = GitHubIssueClient(token, args.repository, args.issue_number)
+    result = run_interactive_trial(
+        client,
+        trial_id=args.trial_id,
+        subject_login=args.subject_login,
+        controller_code_sha=args.controller_code_sha,
+        config_file=args.config_file,
+        config_repository=args.config_repository,
+        config_commit=args.config_commit,
+        config_path=args.config_path,
+        ledger_dir=args.ledger_dir,
+        output_path=args.output,
+        timeout_seconds=args.timeout_seconds,
+    )
+    print(
+        compact_json(
+            {
+                "trial_id": args.trial_id,
+                "valid": result["verification"]["valid"],
+                "configuration_binding_hash": result["ledger"][
+                    "configuration_binding_hash"
+                ],
+                "ledger_hash": result["reveal"]["ledger_hash"],
+                "ledger_commit": result["reveal"]["ledger_commit"],
+            }
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/sais/rcl_bound_controller.py
+++ b/src/sais/rcl_bound_controller.py
@@ -68,8 +68,21 @@ def expected_action(truth: dict[str, str]) -> dict[str, Any]:
 
 
 def validate_probability_record(
-    value: dict[str, Any], expected_binding_hash: str
+    value: dict[str, Any],
+    expected_binding_hash: str,
+    *,
+    observed_probe: str | None = None,
 ) -> None:
+    expected_fields = {
+        "p_success",
+        "configuration_binding_hash",
+        "required_components",
+        "rationale",
+    }
+    if observed_probe is not None:
+        expected_fields.add("observed_probe")
+    if set(value) != expected_fields:
+        raise ValueError("subject forecast fields do not match the frozen protocol")
     probability = value.get("p_success")
     if (
         not isinstance(probability, (int, float))
@@ -79,6 +92,40 @@ def validate_probability_record(
         raise ValueError("p_success must be a number in [0,1]")
     if value.get("configuration_binding_hash") != expected_binding_hash:
         raise ValueError("subject record does not echo the configuration binding")
+    components = value.get("required_components")
+    if (
+        not isinstance(components, list)
+        or not components
+        or any(not isinstance(item, str) or not item.strip() for item in components)
+        or len(components) != len(set(components))
+    ):
+        raise ValueError("required_components must be unique non-empty strings")
+    rationale = value.get("rationale")
+    if not isinstance(rationale, str) or not rationale.strip():
+        raise ValueError("forecast rationale must be a non-empty string")
+    if observed_probe is not None and value.get("observed_probe") != observed_probe:
+        raise ValueError("forecast1 observed_probe does not match controller probe")
+
+
+def validate_diagnosis_record(
+    value: dict[str, Any], expected_binding_hash: str, observed_action: str
+) -> None:
+    if set(value) != {
+        "claimed_condition",
+        "configuration_binding_hash",
+        "observed_action",
+        "rationale",
+    }:
+        raise ValueError("diagnosis fields do not match the frozen protocol")
+    if value.get("configuration_binding_hash") != expected_binding_hash:
+        raise ValueError("diagnosis does not echo the configuration binding")
+    if value.get("observed_action") != observed_action:
+        raise ValueError("diagnosis observed_action does not match controller action")
+    if value.get("claimed_condition") not in {"available", "degraded"}:
+        raise ValueError("claimed_condition must be available or degraded")
+    rationale = value.get("rationale")
+    if not isinstance(rationale, str) or not rationale.strip():
+        raise ValueError("diagnosis rationale must be a non-empty string")
 
 
 def event_body(
@@ -250,6 +297,8 @@ def persist_sealed_ledger(
         capture_output=True,
         text=True,
     ).stdout.strip()
+    if not COMMIT_RE.fullmatch(commit_sha):
+        raise RuntimeError("sealed ledger commit was not a full Git SHA")
     return ledger_hash, commit_sha
 
 
@@ -267,6 +316,14 @@ def run_interactive_trial(
     output_path: Path,
     timeout_seconds: int,
 ) -> dict[str, Any]:
+    if not TRIAL_ID_RE.fullmatch(trial_id):
+        raise ValueError("unsafe RCL trial id")
+    if not SUBJECT_LOGIN_RE.fullmatch(subject_login):
+        raise ValueError("unsafe subject login")
+    if not COMMIT_RE.fullmatch(controller_code_sha):
+        raise ValueError("controller code SHA must be a full lowercase Git SHA")
+    if client.issue_number < 1:
+        raise ValueError("issue number must be positive")
     validate_reference(config_repository, config_commit, config_path)
     config, raw_config = load_product_config(config_file)
     binding = build_binding(
@@ -358,9 +415,7 @@ def run_interactive_trial(
         int(probe_comment["id"]),
         timeout_seconds,
     )
-    validate_probability_record(forecast1, bound_hash)
-    if forecast1.get("observed_probe") != probe_response:
-        raise ValueError("forecast1 observed_probe does not match controller probe")
+    validate_probability_record(forecast1, bound_hash, observed_probe=probe_response)
     action = expected_action(truth)
     perform_payload = {
         "configuration_binding_hash": bound_hash,
@@ -389,12 +444,7 @@ def run_interactive_trial(
         int(action_comment["id"]),
         timeout_seconds,
     )
-    if diagnosis.get("configuration_binding_hash") != bound_hash:
-        raise ValueError("diagnosis does not echo the configuration binding")
-    if diagnosis.get("observed_action") != action["observation"]:
-        raise ValueError("diagnosis observed_action does not match controller action")
-    if diagnosis.get("claimed_condition") not in {"available", "degraded"}:
-        raise ValueError("claimed_condition must be available or degraded")
+    validate_diagnosis_record(diagnosis, bound_hash, action["observation"])
     diagnosis_payload = {
         "configuration_binding_hash": bound_hash,
         "diagnosis": diagnosis,

--- a/src/sais/rcl_bound_evidence.py
+++ b/src/sais/rcl_bound_evidence.py
@@ -1,0 +1,505 @@
+"""Public GitHub collection and offline verification for config-bound RCL trials."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import binascii
+import hashlib
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+from .config_binding import (
+    COMMIT_RE,
+    REPOSITORY_RE,
+    binding_hash,
+    validate_product_config,
+    validate_reference,
+    verify_binding_bytes,
+)
+from .ephemeral_controller import object_hash
+from .public_evidence import (
+    PublicEvidenceError,
+    _api_get,
+    _fetch_comments,
+    git_blob_sha1,
+)
+from .rcl_bound_controller import (
+    ACTION_PREFIX,
+    COMMIT_PREFIX,
+    DIAGNOSIS_PREFIX,
+    FORECAST0_PREFIX,
+    FORECAST1_PREFIX,
+    PROBE_PREFIX,
+    PROTOCOL_VERSION,
+    READY_PREFIX,
+    REVEAL_PREFIX,
+    SEAL_PREFIX,
+    TRIAL_ID_RE,
+    verify_sealed_trial,
+)
+
+PREFIXES = (
+    READY_PREFIX,
+    FORECAST0_PREFIX,
+    COMMIT_PREFIX,
+    PROBE_PREFIX,
+    FORECAST1_PREFIX,
+    ACTION_PREFIX,
+    DIAGNOSIS_PREFIX,
+    SEAL_PREFIX,
+    REVEAL_PREFIX,
+)
+CONTROLLER_PREFIXES = (
+    READY_PREFIX,
+    COMMIT_PREFIX,
+    PROBE_PREFIX,
+    ACTION_PREFIX,
+    SEAL_PREFIX,
+    REVEAL_PREFIX,
+)
+
+
+def _author(comment: dict[str, Any]) -> str | None:
+    user = comment.get("user")
+    return user.get("login") if isinstance(user, dict) else comment.get("author")
+
+
+def _payload(comment: dict[str, Any], prefix: str) -> dict[str, Any]:
+    body = str(comment.get("body", ""))
+    if not body.startswith(prefix):
+        raise ValueError("comment phase prefix mismatch")
+    value = json.loads(body[len(prefix) :])
+    if not isinstance(value, dict):
+        raise ValueError("comment payload must be an object")
+    return value
+
+
+def _indexed_controller_comments(
+    comments: list[dict[str, Any]], controller_actor: str
+) -> dict[str, dict[str, Any]]:
+    found = {}
+    for prefix in CONTROLLER_PREFIXES:
+        matches = [
+            item
+            for item in comments
+            if str(item.get("body", "")).startswith(prefix)
+            and _author(item) == controller_actor
+        ]
+        if len(matches) != 1:
+            message = (
+                f"expected one {prefix.strip()} from {controller_actor}, "
+                f"found {len(matches)}"
+            )
+            raise ValueError(message)
+        found[prefix] = matches[0]
+    return found
+
+
+def _comment_by_id(comments: list[dict[str, Any]], comment_id: Any) -> dict[str, Any]:
+    target = int(comment_id)
+    matches = [item for item in comments if int(item.get("id", -1)) == target]
+    if len(matches) != 1:
+        raise ValueError(f"expected one comment id {target}, found {len(matches)}")
+    return matches[0]
+
+
+def _source_matches(comment: dict[str, Any], source: dict[str, Any]) -> bool:
+    return (
+        int(comment.get("id", -1)) == int(source.get("id", -2))
+        and _author(comment) == source.get("author")
+        and comment.get("created_at") == source.get("created_at")
+    )
+
+
+def _decode_source(source: dict[str, Any]) -> tuple[bytes, Any]:
+    raw = base64.b64decode(source["content_base64"], validate=True)
+    return raw, json.loads(raw)
+
+
+def verify_public_trial(
+    bundle: dict[str, Any],
+    *,
+    expected_repository: str | None = None,
+    expected_controller_actor: str | None = None,
+    expected_subject_actor: str | None = None,
+    expected_controller_code_sha: str | None = None,
+) -> dict[str, bool]:
+    try:
+        ledger = bundle["ledger"]
+        reveal = bundle["reveal"]
+        config = bundle["configuration"]
+        public = bundle["public_record"]
+        controller_actor = str(public["controller_actor"])
+        comments = public["comments"]
+        indexed = _indexed_controller_comments(comments, controller_actor)
+        history = ledger["history"]
+        commit_event, probe_event, perform_event, diagnosis_event = history
+        commit = commit_event["payload"]
+        probe = probe_event["payload"]
+        performed = perform_event["payload"]
+        diagnosis = diagnosis_event["payload"]
+        ready_c = indexed[READY_PREFIX]
+        commit_c = indexed[COMMIT_PREFIX]
+        probe_c = indexed[PROBE_PREFIX]
+        action_c = indexed[ACTION_PREFIX]
+        seal_c = indexed[SEAL_PREFIX]
+        reveal_c = indexed[REVEAL_PREFIX]
+        forecast0_c = _comment_by_id(comments, commit["source_comment"]["id"])
+        forecast1_c = _comment_by_id(comments, performed["source_comment"]["id"])
+        diagnosis_c = _comment_by_id(comments, diagnosis["source_comment"]["id"])
+        raw_ledger, parsed_ledger = _decode_source(public["ledger_source"])
+        raw_config, parsed_config = _decode_source(public["configuration_source"])
+        validate_product_config(config)
+    except (
+        KeyError,
+        TypeError,
+        ValueError,
+        json.JSONDecodeError,
+        binascii.Error,
+    ):
+        return {"public_structure_valid": False, "valid": False}
+
+    try:
+        ready = _payload(ready_c, READY_PREFIX)
+        forecast0 = _payload(forecast0_c, FORECAST0_PREFIX)
+        commit_comment = _payload(commit_c, COMMIT_PREFIX)
+        probe_comment = _payload(probe_c, PROBE_PREFIX)
+        forecast1 = _payload(forecast1_c, FORECAST1_PREFIX)
+        action_comment = _payload(action_c, ACTION_PREFIX)
+        diagnosis_comment = _payload(diagnosis_c, DIAGNOSIS_PREFIX)
+        seal_comment = _payload(seal_c, SEAL_PREFIX)
+        reveal_comment = _payload(reveal_c, REVEAL_PREFIX)
+    except (ValueError, json.JSONDecodeError):
+        return {"public_structure_valid": False, "valid": False}
+
+    trial_id = str(ledger["trial_id"])
+    code_sha = str(ledger["controller_code_sha"])
+    subject = str(ledger["subject_login"])
+    binding = ledger["configuration_binding"]
+    bound_hash = binding_hash(binding)
+    repository = public.get("repository")
+    ledger_source = public["ledger_source"]
+    config_source = public["configuration_source"]
+    comment_ids = [int(item["id"]) for item in comments]
+    positions = {comment_id: index for index, comment_id in enumerate(comment_ids)}
+    selected = {
+        READY_PREFIX: ready_c,
+        FORECAST0_PREFIX: forecast0_c,
+        COMMIT_PREFIX: commit_c,
+        PROBE_PREFIX: probe_c,
+        FORECAST1_PREFIX: forecast1_c,
+        ACTION_PREFIX: action_c,
+        DIAGNOSIS_PREFIX: diagnosis_c,
+        SEAL_PREFIX: seal_c,
+        REVEAL_PREFIX: reveal_c,
+    }
+    ordered_ids = [int(selected[prefix]["id"]) for prefix in PREFIXES]
+
+    expected_ready = {
+        "protocol_version": PROTOCOL_VERSION,
+        "trial_id": trial_id,
+        "controller_code_sha": code_sha,
+        "configuration_binding": binding,
+        "configuration_binding_hash": bound_hash,
+        "next": FORECAST0_PREFIX.strip(),
+    }
+    expected_commit = {
+        "trial_id": trial_id,
+        "commitment": commit["commitment"],
+        "configuration_binding_hash": bound_hash,
+        "forecast0_hash": commit["forecast0_hash"],
+        "event_hash": commit_event["event_hash"],
+        "controller_code_sha": code_sha,
+    }
+    expected_probe = {
+        "trial_id": trial_id,
+        "configuration_binding_hash": bound_hash,
+        "probe_response": probe["probe_response"],
+    }
+    expected_action = {
+        "trial_id": trial_id,
+        "configuration_binding_hash": bound_hash,
+        **performed["action"],
+    }
+    expected_seal = {
+        "protocol_version": PROTOCOL_VERSION,
+        "trial_id": trial_id,
+        "controller_code_sha": code_sha,
+        "configuration_binding_hash": bound_hash,
+        "config_sha256": binding["config_sha256"],
+        "ledger_hash": reveal["ledger_hash"],
+        "ledger_commit": reveal["ledger_commit"],
+    }
+
+    crypto = verify_sealed_trial(ledger, reveal)
+    binding_checks = verify_binding_bytes(binding, config, raw_config)
+    checks: dict[str, bool] = {
+        **{
+            f"crypto_{name}": bool(value)
+            for name, value in crypto.items()
+            if name != "valid"
+        },
+        **{
+            f"config_{name}": bool(value)
+            for name, value in binding_checks.items()
+            if name != "valid"
+        },
+        "public_structure_valid": True,
+        "cryptographic_trial_valid": bool(crypto.get("valid")),
+        "configuration_binding_valid": bool(binding_checks.get("valid")),
+        "repository_present": isinstance(repository, str)
+        and repository.count("/") == 1,
+        "repository_matches_expected": expected_repository is None
+        or repository == expected_repository,
+        "binding_repository_matches_public": binding.get("repository") == repository,
+        "controller_actor_matches_expected": expected_controller_actor is None
+        or controller_actor == expected_controller_actor,
+        "subject_actor_matches_expected": expected_subject_actor is None
+        or subject == expected_subject_actor,
+        "controller_code_matches_expected": expected_controller_code_sha is None
+        or code_sha == expected_controller_code_sha,
+        "controller_subject_distinct": controller_actor != subject,
+        "all_comment_ids_unique": len(comment_ids) == len(set(comment_ids)),
+        "selected_comment_ids_unique": len(ordered_ids) == len(set(ordered_ids)),
+        "protocol_comment_ids_increase": ordered_ids == sorted(ordered_ids),
+        "public_protocol_order": [positions[item] for item in ordered_ids]
+        == sorted(positions[item] for item in ordered_ids),
+        "controller_actor_consistent": all(
+            _author(item) == controller_actor
+            for item in (ready_c, commit_c, probe_c, action_c, seal_c, reveal_c)
+        ),
+        "subject_actor_consistent": all(
+            _author(item) == subject for item in (forecast0_c, forecast1_c, diagnosis_c)
+        ),
+        "ready_body_matches": ready == expected_ready,
+        "ready_comment_id_matches": int(ready_c["id"])
+        == int(commit["ready_comment_id"]),
+        "forecast0_body_matches": forecast0 == commit["forecast0"],
+        "forecast0_source_matches": _source_matches(
+            forecast0_c, commit["source_comment"]
+        ),
+        "commit_body_matches": commit_comment == expected_commit,
+        "probe_body_matches": probe_comment == expected_probe,
+        "probe_source_matches": _source_matches(probe_c, probe["controller_comment"]),
+        "forecast1_body_matches": forecast1 == performed["forecast1"],
+        "forecast1_source_matches": _source_matches(
+            forecast1_c, performed["source_comment"]
+        ),
+        "forecast1_probe_id_matches": int(probe_c["id"])
+        == int(performed["probe_comment_id"]),
+        "action_body_matches": action_comment == expected_action,
+        "action_comment_id_matches": int(action_c["id"])
+        == int(diagnosis["action_comment_id"]),
+        "diagnosis_body_matches": diagnosis_comment == diagnosis["diagnosis"],
+        "diagnosis_source_matches": _source_matches(
+            diagnosis_c, diagnosis["source_comment"]
+        ),
+        "seal_body_matches": seal_comment == expected_seal,
+        "seal_comment_id_matches": int(seal_c["id"]) == int(reveal["seal_comment_id"]),
+        "seal_precedes_reveal": positions[int(seal_c["id"])]
+        < positions[int(reveal_c["id"])],
+        "reveal_body_matches": reveal_comment == reveal,
+        "ledger_issue_matches": int(ledger["issue_number"])
+        == int(public["issue_number"]),
+        "ledger_raw_json_matches": parsed_ledger == ledger,
+        "ledger_source_repository_matches": ledger_source.get("repository")
+        == repository,
+        "ledger_source_commit_matches": ledger_source.get("commit")
+        == reveal["ledger_commit"],
+        "ledger_source_path_matches": ledger_source.get("path")
+        == f"rcl-controller/{trial_id}.json",
+        "ledger_blob_sha_matches": ledger_source.get("api_blob_sha")
+        == git_blob_sha1(raw_ledger),
+        "ledger_bytes_sha256_matches": ledger_source.get("content_sha256")
+        == hashlib.sha256(raw_ledger).hexdigest(),
+        "ledger_object_hash_matches": object_hash(parsed_ledger)
+        == reveal["ledger_hash"],
+        "configuration_object_matches": parsed_config == config,
+        "config_source_repository_matches": config_source.get("repository")
+        == binding.get("repository"),
+        "config_source_commit_matches": config_source.get("commit")
+        == binding.get("commit"),
+        "config_source_path_matches": config_source.get("path") == binding.get("path"),
+        "config_blob_sha_matches": config_source.get("api_blob_sha")
+        == git_blob_sha1(raw_config),
+        "config_source_content_sha256_matches": config_source.get("content_sha256")
+        == hashlib.sha256(raw_config).hexdigest(),
+        "config_bytes_sha256_matches": config_source.get("content_sha256")
+        == binding.get("config_sha256"),
+    }
+    checks["valid"] = all(checks.values())
+    return checks
+
+
+def _content_record(
+    repository: str, commit: str, path: str, token: str | None
+) -> dict[str, Any]:
+    encoded_path = quote(path, safe="/")
+    url = (
+        f"https://api.github.com/repos/{repository}/contents/{encoded_path}"
+        f"?ref={quote(commit, safe='')}"
+    )
+    record = _api_get(url, token)
+    if record.get("type") != "file" or record.get("encoding") != "base64":
+        raise PublicEvidenceError(f"GitHub source is not a base64 file: {path}")
+    return record
+
+
+def _source_from_record(
+    record: dict[str, Any], *, repository: str, commit: str, path: str
+) -> tuple[dict[str, Any], bytes]:
+    try:
+        raw = base64.b64decode(record["content"], validate=True)
+    except (KeyError, binascii.Error) as error:
+        raise PublicEvidenceError(f"invalid base64 source: {path}") from error
+    return {
+        "repository": repository,
+        "commit": commit,
+        "path": path,
+        "api_blob_sha": record["sha"],
+        "content_sha256": hashlib.sha256(raw).hexdigest(),
+        "content_base64": base64.b64encode(raw).decode(),
+    }, raw
+
+
+def collect_public_trial(
+    repository: str,
+    issue_number: int,
+    token: str | None = None,
+    *,
+    controller_actor: str = "github-actions[bot]",
+    expected_subject_actor: str | None = None,
+    expected_controller_code_sha: str | None = None,
+) -> dict[str, Any]:
+    if not REPOSITORY_RE.fullmatch(repository):
+        raise ValueError("repository must be owner/name")
+    if issue_number < 1:
+        raise ValueError("issue_number must be positive")
+    if not controller_actor:
+        raise ValueError("controller_actor must be non-empty")
+    raw_comments = _fetch_comments(repository, issue_number, token)
+    comments = [
+        {
+            "id": int(item["id"]),
+            "created_at": item.get("created_at"),
+            "user": {"login": item.get("user", {}).get("login")},
+            "body": item.get("body", ""),
+        }
+        for item in raw_comments
+        if str(item.get("body", "")).startswith("SAIS_RCL_")
+    ]
+    try:
+        indexed = _indexed_controller_comments(comments, controller_actor)
+        reveal = _payload(indexed[REVEAL_PREFIX], REVEAL_PREFIX)
+        trial_id = str(reveal["trial_id"])
+        ledger_commit = str(reveal["ledger_commit"])
+        if not TRIAL_ID_RE.fullmatch(trial_id):
+            raise ValueError("unsafe trial id in reveal")
+        if not COMMIT_RE.fullmatch(ledger_commit):
+            raise ValueError("unsafe ledger commit in reveal")
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
+        raise PublicEvidenceError(
+            f"cannot identify config-bound RCL trial: {error}"
+        ) from error
+
+    ledger_path = f"rcl-controller/{trial_id}.json"
+    validate_reference(repository, ledger_commit, ledger_path)
+    ledger_record = _content_record(repository, ledger_commit, ledger_path, token)
+    ledger_source, raw_ledger = _source_from_record(
+        ledger_record, repository=repository, commit=ledger_commit, path=ledger_path
+    )
+    ledger = json.loads(raw_ledger)
+    binding = ledger["configuration_binding"]
+    config_repository = str(binding["repository"])
+    config_commit = str(binding["commit"])
+    config_path = str(binding["path"])
+    validate_reference(config_repository, config_commit, config_path)
+    if config_repository != repository:
+        raise PublicEvidenceError(
+            "configuration repository differs from trial repository"
+        )
+    config_record = _content_record(
+        config_repository, config_commit, config_path, token
+    )
+    config_source, raw_config = _source_from_record(
+        config_record,
+        repository=config_repository,
+        commit=config_commit,
+        path=config_path,
+    )
+    configuration = json.loads(raw_config)
+
+    bundle = {
+        "ledger": ledger,
+        "reveal": reveal,
+        "configuration": configuration,
+        "public_record": {
+            "repository": repository,
+            "issue_number": issue_number,
+            "controller_actor": controller_actor,
+            "collected_at_utc": datetime.now(timezone.utc).isoformat(),
+            "comments": comments,
+            "ledger_source": ledger_source,
+            "configuration_source": config_source,
+        },
+    }
+    verification = verify_public_trial(
+        bundle,
+        expected_repository=repository,
+        expected_controller_actor=controller_actor,
+        expected_subject_actor=expected_subject_actor,
+        expected_controller_code_sha=expected_controller_code_sha,
+    )
+    bundle["public_verification"] = verification
+    if not verification.get("valid"):
+        failed = sorted(name for name, passed in verification.items() if not passed)
+        raise PublicEvidenceError(
+            "config-bound public verification failed: " + ", ".join(failed)
+        )
+    return bundle
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("repository")
+    parser.add_argument("issue_number", type=int)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--controller-actor", default="github-actions[bot]")
+    parser.add_argument("--subject-actor")
+    parser.add_argument("--controller-code-sha")
+    args = parser.parse_args()
+    token = os.environ.get("GITHUB_TOKEN") or None
+    bundle = collect_public_trial(
+        args.repository,
+        args.issue_number,
+        token,
+        controller_actor=args.controller_actor,
+        expected_subject_actor=args.subject_actor,
+        expected_controller_code_sha=args.controller_code_sha,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(bundle, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    print(
+        json.dumps(
+            {
+                "trial_id": bundle["ledger"]["trial_id"],
+                "valid": bundle["public_verification"]["valid"],
+                "configuration_binding_hash": bundle["ledger"][
+                    "configuration_binding_hash"
+                ],
+                "output": str(args.output),
+            },
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/sais/rcl_bound_evidence.py
+++ b/src/sais/rcl_bound_evidence.py
@@ -14,11 +14,13 @@ from typing import Any
 from urllib.parse import quote
 
 from .config_binding import (
+    BLOCK_ID_RE,
     COMMIT_RE,
-    REPOSITORY_RE,
     binding_hash,
     validate_product_config,
     validate_reference,
+    validate_repository_name,
+    validate_repository_path,
     verify_binding_bytes,
 )
 from .ephemeral_controller import object_hash
@@ -39,6 +41,7 @@ from .rcl_bound_controller import (
     READY_PREFIX,
     REVEAL_PREFIX,
     SEAL_PREFIX,
+    SUBJECT_LOGIN_RE,
     TRIAL_ID_RE,
     verify_sealed_trial,
 )
@@ -116,8 +119,12 @@ def _source_matches(comment: dict[str, Any], source: dict[str, Any]) -> bool:
     )
 
 
-def _decode_source(source: dict[str, Any]) -> tuple[bytes, Any]:
-    raw = base64.b64decode(source["content_base64"], validate=True)
+def _decode_bytes(source: dict[str, Any]) -> bytes:
+    return base64.b64decode(source["content_base64"], validate=True)
+
+
+def _decode_json_source(source: dict[str, Any]) -> tuple[bytes, Any]:
+    raw = _decode_bytes(source)
     return raw, json.loads(raw)
 
 
@@ -128,6 +135,9 @@ def verify_public_trial(
     expected_controller_actor: str | None = None,
     expected_subject_actor: str | None = None,
     expected_controller_code_sha: str | None = None,
+    expected_configuration_commit: str | None = None,
+    expected_configuration_path: str | None = None,
+    expected_block_id: str | None = None,
 ) -> dict[str, bool]:
     try:
         ledger = bundle["ledger"]
@@ -152,8 +162,10 @@ def verify_public_trial(
         forecast0_c = _comment_by_id(comments, commit["source_comment"]["id"])
         forecast1_c = _comment_by_id(comments, performed["source_comment"]["id"])
         diagnosis_c = _comment_by_id(comments, diagnosis["source_comment"]["id"])
-        raw_ledger, parsed_ledger = _decode_source(public["ledger_source"])
-        raw_config, parsed_config = _decode_source(public["configuration_source"])
+        raw_ledger, parsed_ledger = _decode_json_source(public["ledger_source"])
+        raw_config, parsed_config = _decode_json_source(public["configuration_source"])
+        raw_instructions = _decode_bytes(public["subject_instruction_source"])
+        raw_instructions.decode("utf-8")
         validate_product_config(config)
     except (
         KeyError,
@@ -185,6 +197,7 @@ def verify_public_trial(
     repository = public.get("repository")
     ledger_source = public["ledger_source"]
     config_source = public["configuration_source"]
+    instruction_source = public["subject_instruction_source"]
     comment_ids = [int(item["id"]) for item in comments]
     positions = {comment_id: index for index, comment_id in enumerate(comment_ids)}
     selected = {
@@ -250,6 +263,12 @@ def verify_public_trial(
             if name != "valid"
         },
         "public_structure_valid": True,
+        "trial_id_format_valid": bool(TRIAL_ID_RE.fullmatch(trial_id)),
+        "controller_code_sha_format_valid": bool(COMMIT_RE.fullmatch(code_sha)),
+        "ledger_commit_format_valid": bool(
+            COMMIT_RE.fullmatch(str(reveal.get("ledger_commit", "")))
+        ),
+        "issue_number_positive": int(public["issue_number"]) > 0,
         "cryptographic_trial_valid": bool(crypto.get("valid")),
         "configuration_binding_valid": bool(binding_checks.get("valid")),
         "repository_present": isinstance(repository, str)
@@ -263,6 +282,12 @@ def verify_public_trial(
         or subject == expected_subject_actor,
         "controller_code_matches_expected": expected_controller_code_sha is None
         or code_sha == expected_controller_code_sha,
+        "configuration_commit_matches_expected": expected_configuration_commit is None
+        or binding.get("commit") == expected_configuration_commit,
+        "configuration_path_matches_expected": expected_configuration_path is None
+        or binding.get("path") == expected_configuration_path,
+        "configuration_block_matches_expected": expected_block_id is None
+        or binding.get("block_id") == expected_block_id,
         "controller_subject_distinct": controller_actor != subject,
         "all_comment_ids_unique": len(comment_ids) == len(set(comment_ids)),
         "selected_comment_ids_unique": len(ordered_ids) == len(set(ordered_ids)),
@@ -331,6 +356,20 @@ def verify_public_trial(
         == hashlib.sha256(raw_config).hexdigest(),
         "config_bytes_sha256_matches": config_source.get("content_sha256")
         == binding.get("config_sha256"),
+        "instruction_source_repository_matches": instruction_source.get("repository")
+        == binding.get("repository"),
+        "instruction_source_commit_matches": instruction_source.get("commit")
+        == binding.get("commit"),
+        "instruction_source_path_matches": instruction_source.get("path")
+        == config.get("subject_instruction_path"),
+        "instruction_blob_sha_matches": instruction_source.get("api_blob_sha")
+        == git_blob_sha1(raw_instructions),
+        "instruction_source_content_sha256_matches": instruction_source.get(
+            "content_sha256"
+        )
+        == hashlib.sha256(raw_instructions).hexdigest(),
+        "instruction_bytes_sha256_matches": hashlib.sha256(raw_instructions).hexdigest()
+        == config.get("subject_instruction_sha256"),
     }
     checks["valid"] = all(checks.values())
     return checks
@@ -375,13 +414,31 @@ def collect_public_trial(
     controller_actor: str = "github-actions[bot]",
     expected_subject_actor: str | None = None,
     expected_controller_code_sha: str | None = None,
+    expected_configuration_commit: str | None = None,
+    expected_configuration_path: str | None = None,
+    expected_block_id: str | None = None,
 ) -> dict[str, Any]:
-    if not REPOSITORY_RE.fullmatch(repository):
-        raise ValueError("repository must be owner/name")
+    validate_repository_name(repository)
     if issue_number < 1:
         raise ValueError("issue_number must be positive")
     if not controller_actor:
         raise ValueError("controller_actor must be non-empty")
+    if expected_subject_actor is not None and not SUBJECT_LOGIN_RE.fullmatch(
+        expected_subject_actor
+    ):
+        raise ValueError("expected subject actor is unsafe")
+    if expected_controller_code_sha is not None and not COMMIT_RE.fullmatch(
+        expected_controller_code_sha
+    ):
+        raise ValueError("expected controller code SHA is invalid")
+    if expected_configuration_commit is not None and not COMMIT_RE.fullmatch(
+        expected_configuration_commit
+    ):
+        raise ValueError("expected configuration commit is invalid")
+    if expected_configuration_path is not None:
+        validate_repository_path(expected_configuration_path)
+    if expected_block_id is not None and not BLOCK_ID_RE.fullmatch(expected_block_id):
+        raise ValueError("expected block id is invalid")
     raw_comments = _fetch_comments(repository, issue_number, token)
     comments = [
         {
@@ -433,6 +490,29 @@ def collect_public_trial(
         path=config_path,
     )
     configuration = json.loads(raw_config)
+    validate_product_config(configuration)
+    instruction_path = str(configuration["subject_instruction_path"])
+    validate_repository_path(instruction_path, label="subject instruction")
+    instruction_record = _content_record(
+        config_repository, config_commit, instruction_path, token
+    )
+    instruction_source, raw_instructions = _source_from_record(
+        instruction_record,
+        repository=config_repository,
+        commit=config_commit,
+        path=instruction_path,
+    )
+    try:
+        raw_instructions.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise PublicEvidenceError("subject instructions are not UTF-8") from error
+    if (
+        hashlib.sha256(raw_instructions).hexdigest()
+        != configuration["subject_instruction_sha256"]
+    ):
+        raise PublicEvidenceError(
+            "subject instruction bytes do not match configuration"
+        )
 
     bundle = {
         "ledger": ledger,
@@ -446,6 +526,7 @@ def collect_public_trial(
             "comments": comments,
             "ledger_source": ledger_source,
             "configuration_source": config_source,
+            "subject_instruction_source": instruction_source,
         },
     }
     verification = verify_public_trial(
@@ -454,6 +535,9 @@ def collect_public_trial(
         expected_controller_actor=controller_actor,
         expected_subject_actor=expected_subject_actor,
         expected_controller_code_sha=expected_controller_code_sha,
+        expected_configuration_commit=expected_configuration_commit,
+        expected_configuration_path=expected_configuration_path,
+        expected_block_id=expected_block_id,
     )
     bundle["public_verification"] = verification
     if not verification.get("valid"):
@@ -472,6 +556,9 @@ def main() -> None:
     parser.add_argument("--controller-actor", default="github-actions[bot]")
     parser.add_argument("--subject-actor")
     parser.add_argument("--controller-code-sha")
+    parser.add_argument("--config-commit")
+    parser.add_argument("--config-path")
+    parser.add_argument("--block-id")
     args = parser.parse_args()
     token = os.environ.get("GITHUB_TOKEN") or None
     bundle = collect_public_trial(
@@ -481,6 +568,9 @@ def main() -> None:
         controller_actor=args.controller_actor,
         expected_subject_actor=args.subject_actor,
         expected_controller_code_sha=args.controller_code_sha,
+        expected_configuration_commit=args.config_commit,
+        expected_configuration_path=args.config_path,
+        expected_block_id=args.block_id,
     )
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(

--- a/src/sais/stage002.py
+++ b/src/sais/stage002.py
@@ -157,7 +157,6 @@ class TrialController:
         assert self.forecast0 and self.entropy and self.condition and self.payload and self.commitment
         reveal = {
             "protocol_version": PROTOCOL_VERSION,
-            "protocol_version": PROTOCOL_VERSION,
             "trial_id": self.trial_id,
             "family": self.family,
             "forecast_lock": _sha256(self.forecast0),

--- a/tests/test_config_bound_controller.py
+++ b/tests/test_config_bound_controller.py
@@ -226,3 +226,54 @@ def test_naive_configuration_timestamp_is_rejected(tmp_path):
     forged.write_text(json.dumps(value), encoding="utf-8")
     with pytest.raises(ValueError, match="include a timezone"):
         load_product_config(forged)
+
+
+def test_non_utc_configuration_timestamp_is_rejected(tmp_path):
+    value = json.loads(CONFIG.read_text(encoding="utf-8"))
+    value["recorded_at_utc"] = "2026-08-31T10:11:25+03:00"
+    forged = tmp_path / "config.json"
+    forged.write_text(json.dumps(value), encoding="utf-8")
+    with pytest.raises(ValueError, match="must use UTC"):
+        load_product_config(forged)
+
+
+def test_instruction_path_traversal_is_rejected(tmp_path):
+    value = json.loads(CONFIG.read_text(encoding="utf-8"))
+    value["subject_instruction_path"] = "../SUBJECT_INSTRUCTIONS.md"
+    forged = tmp_path / "config.json"
+    forged.write_text(json.dumps(value), encoding="utf-8")
+    with pytest.raises(ValueError, match="unsafe subject instruction path"):
+        load_product_config(forged)
+
+
+def test_symlinked_configuration_is_rejected(tmp_path):
+    target = tmp_path / "target.json"
+    target.write_bytes(CONFIG.read_bytes())
+    link = tmp_path / "config.json"
+    link.symlink_to(target)
+    with pytest.raises(ValueError, match="regular file"):
+        load_product_config(link)
+
+
+def test_forecast_fields_are_protocol_closed():
+    value = {
+        "p_success": 0.5,
+        "configuration_binding_hash": "a" * 64,
+        "required_components": ["controller"],
+        "rationale": "baseline",
+        "unfrozen_extra": True,
+    }
+    with pytest.raises(ValueError, match="fields do not match"):
+        controller.validate_probability_record(value, "a" * 64)
+
+
+def test_repository_dot_segment_is_rejected():
+    with pytest.raises(ValueError, match="unsafe configuration repository"):
+        validate_reference("../repo", CONFIG_COMMIT, CONFIG_PATH)
+
+
+def test_noncanonical_repository_path_is_rejected():
+    with pytest.raises(ValueError, match="unsafe configuration path"):
+        validate_reference(
+            "Abdullah-m7/science-of-ai-systems", CONFIG_COMMIT, "a//config.json"
+        )

--- a/tests/test_config_bound_controller.py
+++ b/tests/test_config_bound_controller.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+import sais.rcl_bound_controller as controller
+from sais.config_binding import (
+    binding_hash,
+    build_binding,
+    load_product_config,
+    validate_reference,
+)
+from sais.rcl_bound_controller import run_interactive_trial, verify_sealed_trial
+
+ROOT = Path(__file__).parents[1]
+CONFIG = (
+    ROOT / "experiments" / "005-config-bound-controller" / "validation" / "CONFIG.json"
+)
+CONFIG_COMMIT = "a" * 40
+CONFIG_PATH = "experiments/005-config-bound-controller/validation/CONFIG.json"
+
+
+class FakeIssueClient:
+    issue_number = 88
+
+    def __init__(self, subject: str = "subject", wrong_binding: bool = False):
+        self.subject = subject
+        self.wrong_binding = wrong_binding
+        self.items: list[dict] = []
+        self.next_id = 1
+
+    def _add(self, author: str, body: str) -> dict:
+        item = {
+            "id": self.next_id,
+            "created_at": f"t{self.next_id}",
+            "user": {"login": author},
+            "body": body,
+        }
+        self.next_id += 1
+        self.items.append(item)
+        return item
+
+    def post(self, body: str) -> dict:
+        return self._add("github-actions[bot]", body)
+
+    def _first(self, prefix: str) -> dict | None:
+        return next(
+            (item for item in self.items if item["body"].startswith(prefix)), None
+        )
+
+    def comments(self) -> list[dict]:
+        ready = self._first(controller.READY_PREFIX)
+        if ready and not self._first(controller.FORECAST0_PREFIX):
+            value = json.loads(ready["body"].split(" ", 1)[1])
+            bound_hash = (
+                "0" * 64 if self.wrong_binding else value["configuration_binding_hash"]
+            )
+            self._add(
+                self.subject,
+                controller.FORECAST0_PREFIX
+                + json.dumps(
+                    {
+                        "p_success": 0.5,
+                        "configuration_binding_hash": bound_hash,
+                        "required_components": ["rcl_remote_controller"],
+                        "rationale": "symmetric before hidden state generation",
+                    }
+                ),
+            )
+        probe = self._first(controller.PROBE_PREFIX)
+        if probe and not self._first(controller.FORECAST1_PREFIX):
+            value = json.loads(probe["body"].split(" ", 1)[1])
+            observed = value["probe_response"]
+            probability = (
+                0.99
+                if observed == "available"
+                else 0.01
+                if observed == "degraded"
+                else 0.5
+            )
+            self._add(
+                self.subject,
+                controller.FORECAST1_PREFIX
+                + json.dumps(
+                    {
+                        "p_success": probability,
+                        "configuration_binding_hash": value[
+                            "configuration_binding_hash"
+                        ],
+                        "observed_probe": observed,
+                        "required_components": ["rcl_remote_controller"],
+                        "rationale": "updated from the visible probe only",
+                    }
+                ),
+            )
+        action = self._first(controller.ACTION_PREFIX)
+        if action and not self._first(controller.DIAGNOSIS_PREFIX):
+            value = json.loads(action["body"].split(" ", 1)[1])
+            self._add(
+                self.subject,
+                controller.DIAGNOSIS_PREFIX
+                + json.dumps(
+                    {
+                        "claimed_condition": "available"
+                        if value["success"]
+                        else "degraded",
+                        "configuration_binding_hash": value[
+                            "configuration_binding_hash"
+                        ],
+                        "observed_action": value["observation"],
+                        "rationale": "diagnosed from the action result",
+                    }
+                ),
+            )
+        return list(self.items)
+
+
+def run_fake(monkeypatch, tmp_path, *, wrong_binding: bool = False):
+    client = FakeIssueClient(wrong_binding=wrong_binding)
+
+    def deterministic_key(_size: int) -> bytes:
+        assert client._first(controller.FORECAST0_PREFIX) is not None
+        return bytes.fromhex("45" * 32)
+
+    monkeypatch.setattr(controller.secrets, "token_bytes", deterministic_key)
+    monkeypatch.setattr(
+        controller,
+        "persist_sealed_ledger",
+        lambda _dir, _trial, ledger: (controller.object_hash(ledger), "b" * 40),
+    )
+    result = run_interactive_trial(
+        client,
+        trial_id="RCL-VAL-001",
+        subject_login="subject",
+        controller_code_sha="c" * 40,
+        config_file=CONFIG,
+        config_repository="Abdullah-m7/science-of-ai-systems",
+        config_commit=CONFIG_COMMIT,
+        config_path=CONFIG_PATH,
+        ledger_dir=tmp_path / "ledger",
+        output_path=tmp_path / "result.json",
+        timeout_seconds=1,
+    )
+    return client, result
+
+
+def test_validation_configuration_builds_byte_binding():
+    config, raw = load_product_config(CONFIG)
+    binding = build_binding(
+        config,
+        raw,
+        repository="Abdullah-m7/science-of-ai-systems",
+        commit=CONFIG_COMMIT,
+        path=CONFIG_PATH,
+    )
+    assert binding["block_id"] == "RCL-VAL-001"
+    assert len(binding["config_sha256"]) == 64
+    assert len(binding_hash(binding)) == 64
+
+
+def test_unsafe_configuration_reference_is_rejected():
+    with pytest.raises(ValueError, match="unsafe configuration path"):
+        validate_reference(
+            "Abdullah-m7/science-of-ai-systems", CONFIG_COMMIT, "../secret.json"
+        )
+
+
+def test_configuration_bound_protocol_end_to_end(monkeypatch, tmp_path):
+    client, result = run_fake(monkeypatch, tmp_path)
+    assert result["verification"]["valid"] is True
+    assert result["ledger"]["configuration_binding"]["commit"] == CONFIG_COMMIT
+    assert (
+        result["ledger"]["configuration_binding_hash"]
+        == result["reveal"]["configuration_binding_hash"]
+    )
+    assert [item["body"].split(" ", 1)[0] for item in client.items] == [
+        "SAIS_RCL_READY",
+        "SAIS_RCL_FORECAST0",
+        "SAIS_RCL_COMMIT",
+        "SAIS_RCL_PROBE",
+        "SAIS_RCL_FORECAST1",
+        "SAIS_RCL_ACTION",
+        "SAIS_RCL_DIAGNOSIS",
+        "SAIS_RCL_SEAL",
+        "SAIS_RCL_REVEAL",
+    ]
+
+
+def test_subject_cannot_echo_a_different_binding(monkeypatch, tmp_path):
+    with pytest.raises(ValueError, match="does not echo"):
+        run_fake(monkeypatch, tmp_path, wrong_binding=True)
+
+
+def test_binding_tamper_breaks_signed_trial(monkeypatch, tmp_path):
+    _client, result = run_fake(monkeypatch, tmp_path)
+    forged_ledger = copy.deepcopy(result["ledger"])
+    forged_reveal = copy.deepcopy(result["reveal"])
+    forged_ledger["configuration_binding"]["path"] = "other/config.json"
+    forged_ledger["configuration_binding_hash"] = binding_hash(
+        forged_ledger["configuration_binding"]
+    )
+    forged_reveal["configuration_binding"] = forged_ledger["configuration_binding"]
+    forged_reveal["configuration_binding_hash"] = forged_ledger[
+        "configuration_binding_hash"
+    ]
+    forged_reveal["ledger_hash"] = controller.object_hash(forged_ledger)
+    assert verify_sealed_trial(forged_ledger, forged_reveal)["valid"] is False
+
+
+def test_unknown_configuration_field_is_rejected(tmp_path):
+    value = json.loads(CONFIG.read_text(encoding="utf-8"))
+    value["unfrozen_field"] = "surprise"
+    forged = tmp_path / "config.json"
+    forged.write_text(json.dumps(value), encoding="utf-8")
+    with pytest.raises(ValueError, match="unknown product configuration fields"):
+        load_product_config(forged)
+
+
+def test_naive_configuration_timestamp_is_rejected(tmp_path):
+    value = json.loads(CONFIG.read_text(encoding="utf-8"))
+    value["recorded_at_utc"] = "2026-08-31T07:11:25"
+    forged = tmp_path / "config.json"
+    forged.write_text(json.dumps(value), encoding="utf-8")
+    with pytest.raises(ValueError, match="include a timezone"):
+        load_product_config(forged)

--- a/tests/test_config_bound_evidence.py
+++ b/tests/test_config_bound_evidence.py
@@ -16,6 +16,8 @@ CONFIG = (
     ROOT / "experiments" / "005-config-bound-controller" / "validation" / "CONFIG.json"
 )
 CONFIG_PATH = "experiments/005-config-bound-controller/validation/CONFIG.json"
+INSTRUCTION_PATH = "experiments/005-config-bound-controller/SUBJECT_INSTRUCTIONS.md"
+INSTRUCTIONS = ROOT / INSTRUCTION_PATH
 CONFIG_COMMIT = "a" * 40
 CODE_SHA = "c" * 40
 LEDGER_COMMIT = "b" * 40
@@ -133,6 +135,7 @@ def make_bundle(monkeypatch, tmp_path):
         json.dumps(result["ledger"], indent=2, sort_keys=True) + "\n"
     ).encode()
     raw_config = CONFIG.read_bytes()
+    raw_instructions = INSTRUCTIONS.read_bytes()
     bundle = {
         "ledger": result["ledger"],
         "reveal": result["reveal"],
@@ -158,6 +161,14 @@ def make_bundle(monkeypatch, tmp_path):
                 "content_sha256": hashlib.sha256(raw_config).hexdigest(),
                 "content_base64": base64.b64encode(raw_config).decode(),
             },
+            "subject_instruction_source": {
+                "repository": REPOSITORY,
+                "commit": CONFIG_COMMIT,
+                "path": INSTRUCTION_PATH,
+                "api_blob_sha": git_blob_sha1(raw_instructions),
+                "content_sha256": hashlib.sha256(raw_instructions).hexdigest(),
+                "content_base64": base64.b64encode(raw_instructions).decode(),
+            },
         },
     }
     return bundle
@@ -170,6 +181,9 @@ def verify(bundle):
         expected_controller_actor="github-actions[bot]",
         expected_subject_actor="subject",
         expected_controller_code_sha=CODE_SHA,
+        expected_configuration_commit=CONFIG_COMMIT,
+        expected_configuration_path=CONFIG_PATH,
+        expected_block_id="RCL-VAL-001",
     )
 
 
@@ -183,6 +197,18 @@ def test_configuration_object_substitution_is_detected(monkeypatch, tmp_path):
     checks = verify(forged)
     assert checks["valid"] is False
     assert checks["configuration_object_matches"] is False
+
+
+def test_subject_instruction_byte_substitution_is_detected(monkeypatch, tmp_path):
+    forged = make_bundle(monkeypatch, tmp_path)
+    replacement = b"substituted subject instructions\n"
+    forged["public_record"]["subject_instruction_source"]["content_base64"] = (
+        base64.b64encode(replacement).decode()
+    )
+    checks = verify(forged)
+    assert checks["valid"] is False
+    assert checks["instruction_blob_sha_matches"] is False
+    assert checks["instruction_bytes_sha256_matches"] is False
 
 
 def test_outsider_reveal_prefix_is_ignored(monkeypatch, tmp_path):
@@ -218,7 +244,28 @@ def test_expected_controller_code_is_enforced(monkeypatch, tmp_path):
     assert checks["controller_code_matches_expected"] is False
 
 
-def test_live_collector_round_trips_two_exact_git_sources(monkeypatch, tmp_path):
+def test_expected_configuration_commit_is_enforced(monkeypatch, tmp_path):
+    bundle = make_bundle(monkeypatch, tmp_path)
+    checks = evidence.verify_public_trial(
+        bundle, expected_configuration_commit="0" * 40
+    )
+    assert checks["valid"] is False
+    assert checks["configuration_commit_matches_expected"] is False
+
+
+def test_expected_configuration_path_and_block_are_enforced(monkeypatch, tmp_path):
+    bundle = make_bundle(monkeypatch, tmp_path)
+    checks = evidence.verify_public_trial(
+        bundle,
+        expected_configuration_path="other/config.json",
+        expected_block_id="OTHER-BLOCK",
+    )
+    assert checks["valid"] is False
+    assert checks["configuration_path_matches_expected"] is False
+    assert checks["configuration_block_matches_expected"] is False
+
+
+def test_live_collector_round_trips_three_exact_git_sources(monkeypatch, tmp_path):
     bundle = make_bundle(monkeypatch, tmp_path)
     public = bundle["public_record"]
     monkeypatch.setattr(
@@ -228,11 +275,12 @@ def test_live_collector_round_trips_two_exact_git_sources(monkeypatch, tmp_path)
     )
 
     def fake_api_get(url, token=None):
-        source = (
-            public["ledger_source"]
-            if "rcl-controller" in url
-            else public["configuration_source"]
-        )
+        if "rcl-controller" in url:
+            source = public["ledger_source"]
+        elif "CONFIG.json" in url:
+            source = public["configuration_source"]
+        else:
+            source = public["subject_instruction_source"]
         return {
             "type": "file",
             "encoding": "base64",
@@ -247,6 +295,9 @@ def test_live_collector_round_trips_two_exact_git_sources(monkeypatch, tmp_path)
         controller_actor="github-actions[bot]",
         expected_subject_actor="subject",
         expected_controller_code_sha=CODE_SHA,
+        expected_configuration_commit=CONFIG_COMMIT,
+        expected_configuration_path=CONFIG_PATH,
+        expected_block_id="RCL-VAL-001",
     )
     assert collected["public_verification"]["valid"] is True
     assert collected["configuration"]["block_id"] == "RCL-VAL-001"
@@ -263,4 +314,20 @@ def test_collector_rejects_unsafe_repository_before_network(monkeypatch):
     monkeypatch.setattr(evidence, "_fetch_comments", should_not_run)
     with pytest.raises(ValueError, match="owner/name"):
         evidence.collect_public_trial("owner/repo/../../other", 1)
+    assert called is False
+
+
+def test_invalid_expected_commit_is_rejected_before_network(monkeypatch):
+    called = False
+
+    def should_not_run(*args, **kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("network should not be reached")
+
+    monkeypatch.setattr(evidence, "_fetch_comments", should_not_run)
+    with pytest.raises(ValueError, match="expected configuration commit"):
+        evidence.collect_public_trial(
+            REPOSITORY, 1, expected_configuration_commit="not-a-commit"
+        )
     assert called is False

--- a/tests/test_config_bound_evidence.py
+++ b/tests/test_config_bound_evidence.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+import sais.rcl_bound_controller as controller
+import sais.rcl_bound_evidence as evidence
+from sais.public_evidence import git_blob_sha1
+
+ROOT = Path(__file__).parents[1]
+CONFIG = (
+    ROOT / "experiments" / "005-config-bound-controller" / "validation" / "CONFIG.json"
+)
+CONFIG_PATH = "experiments/005-config-bound-controller/validation/CONFIG.json"
+CONFIG_COMMIT = "a" * 40
+CODE_SHA = "c" * 40
+LEDGER_COMMIT = "b" * 40
+REPOSITORY = "Abdullah-m7/science-of-ai-systems"
+
+
+class FakeClient:
+    issue_number = 88
+
+    def __init__(self):
+        self.items = []
+        self.next_id = 1
+
+    def _add(self, author, body):
+        item = {
+            "id": self.next_id,
+            "created_at": f"t{self.next_id}",
+            "user": {"login": author},
+            "body": body,
+        }
+        self.next_id += 1
+        self.items.append(item)
+        return item
+
+    def post(self, body):
+        return self._add("github-actions[bot]", body)
+
+    def _first(self, prefix):
+        return next(
+            (item for item in self.items if item["body"].startswith(prefix)), None
+        )
+
+    def comments(self):
+        ready = self._first(controller.READY_PREFIX)
+        if ready and not self._first(controller.FORECAST0_PREFIX):
+            value = json.loads(ready["body"].split(" ", 1)[1])
+            self._add(
+                "subject",
+                controller.FORECAST0_PREFIX
+                + json.dumps(
+                    {
+                        "p_success": 0.5,
+                        "configuration_binding_hash": value[
+                            "configuration_binding_hash"
+                        ],
+                        "required_components": ["rcl_remote_controller"],
+                        "rationale": "baseline",
+                    }
+                ),
+            )
+        probe = self._first(controller.PROBE_PREFIX)
+        if probe and not self._first(controller.FORECAST1_PREFIX):
+            value = json.loads(probe["body"].split(" ", 1)[1])
+            self._add(
+                "subject",
+                controller.FORECAST1_PREFIX
+                + json.dumps(
+                    {
+                        "p_success": 0.5,
+                        "configuration_binding_hash": value[
+                            "configuration_binding_hash"
+                        ],
+                        "observed_probe": value["probe_response"],
+                        "required_components": ["rcl_remote_controller"],
+                        "rationale": "probe update",
+                    }
+                ),
+            )
+        action = self._first(controller.ACTION_PREFIX)
+        if action and not self._first(controller.DIAGNOSIS_PREFIX):
+            value = json.loads(action["body"].split(" ", 1)[1])
+            self._add(
+                "subject",
+                controller.DIAGNOSIS_PREFIX
+                + json.dumps(
+                    {
+                        "claimed_condition": "available"
+                        if value["success"]
+                        else "degraded",
+                        "configuration_binding_hash": value[
+                            "configuration_binding_hash"
+                        ],
+                        "observed_action": value["observation"],
+                        "rationale": "action diagnosis",
+                    }
+                ),
+            )
+        return list(self.items)
+
+
+def make_bundle(monkeypatch, tmp_path):
+    client = FakeClient()
+    monkeypatch.setattr(
+        controller.secrets, "token_bytes", lambda _size: bytes.fromhex("45" * 32)
+    )
+    monkeypatch.setattr(
+        controller,
+        "persist_sealed_ledger",
+        lambda _dir, _trial, ledger: (controller.object_hash(ledger), LEDGER_COMMIT),
+    )
+    result = controller.run_interactive_trial(
+        client,
+        trial_id="RCL-VAL-001",
+        subject_login="subject",
+        controller_code_sha=CODE_SHA,
+        config_file=CONFIG,
+        config_repository=REPOSITORY,
+        config_commit=CONFIG_COMMIT,
+        config_path=CONFIG_PATH,
+        ledger_dir=tmp_path / "ledger",
+        output_path=tmp_path / "result.json",
+        timeout_seconds=1,
+    )
+    raw_ledger = (
+        json.dumps(result["ledger"], indent=2, sort_keys=True) + "\n"
+    ).encode()
+    raw_config = CONFIG.read_bytes()
+    bundle = {
+        "ledger": result["ledger"],
+        "reveal": result["reveal"],
+        "configuration": json.loads(raw_config),
+        "public_record": {
+            "repository": REPOSITORY,
+            "issue_number": 88,
+            "controller_actor": "github-actions[bot]",
+            "comments": client.items,
+            "ledger_source": {
+                "repository": REPOSITORY,
+                "commit": LEDGER_COMMIT,
+                "path": "rcl-controller/RCL-VAL-001.json",
+                "api_blob_sha": git_blob_sha1(raw_ledger),
+                "content_sha256": hashlib.sha256(raw_ledger).hexdigest(),
+                "content_base64": base64.b64encode(raw_ledger).decode(),
+            },
+            "configuration_source": {
+                "repository": REPOSITORY,
+                "commit": CONFIG_COMMIT,
+                "path": CONFIG_PATH,
+                "api_blob_sha": git_blob_sha1(raw_config),
+                "content_sha256": hashlib.sha256(raw_config).hexdigest(),
+                "content_base64": base64.b64encode(raw_config).decode(),
+            },
+        },
+    }
+    return bundle
+
+
+def verify(bundle):
+    return evidence.verify_public_trial(
+        bundle,
+        expected_repository=REPOSITORY,
+        expected_controller_actor="github-actions[bot]",
+        expected_subject_actor="subject",
+        expected_controller_code_sha=CODE_SHA,
+    )
+
+
+def test_public_bundle_verifies_ledger_and_configuration_bytes(monkeypatch, tmp_path):
+    assert verify(make_bundle(monkeypatch, tmp_path))["valid"] is True
+
+
+def test_configuration_object_substitution_is_detected(monkeypatch, tmp_path):
+    forged = make_bundle(monkeypatch, tmp_path)
+    forged["configuration"]["notes"] = "substituted"
+    checks = verify(forged)
+    assert checks["valid"] is False
+    assert checks["configuration_object_matches"] is False
+
+
+def test_outsider_reveal_prefix_is_ignored(monkeypatch, tmp_path):
+    forged = make_bundle(monkeypatch, tmp_path)
+    forged["public_record"]["comments"].append(
+        {
+            "id": 999,
+            "created_at": "t999",
+            "user": {"login": "outsider"},
+            "body": 'SAIS_RCL_REVEAL {"forged":true}',
+        }
+    )
+    assert verify(forged)["valid"] is True
+
+
+def test_duplicate_frozen_controller_phase_is_rejected(monkeypatch, tmp_path):
+    forged = make_bundle(monkeypatch, tmp_path)
+    forged["public_record"]["comments"].append(
+        {
+            "id": 999,
+            "created_at": "t999",
+            "user": {"login": "github-actions[bot]"},
+            "body": 'SAIS_RCL_COMMIT {"forged":true}',
+        }
+    )
+    assert verify(forged)["valid"] is False
+
+
+def test_expected_controller_code_is_enforced(monkeypatch, tmp_path):
+    bundle = make_bundle(monkeypatch, tmp_path)
+    checks = evidence.verify_public_trial(bundle, expected_controller_code_sha="0" * 40)
+    assert checks["valid"] is False
+    assert checks["controller_code_matches_expected"] is False
+
+
+def test_live_collector_round_trips_two_exact_git_sources(monkeypatch, tmp_path):
+    bundle = make_bundle(monkeypatch, tmp_path)
+    public = bundle["public_record"]
+    monkeypatch.setattr(
+        evidence,
+        "_fetch_comments",
+        lambda repository, issue_number, token: public["comments"],
+    )
+
+    def fake_api_get(url, token=None):
+        source = (
+            public["ledger_source"]
+            if "rcl-controller" in url
+            else public["configuration_source"]
+        )
+        return {
+            "type": "file",
+            "encoding": "base64",
+            "content": source["content_base64"],
+            "sha": source["api_blob_sha"],
+        }
+
+    monkeypatch.setattr(evidence, "_api_get", fake_api_get)
+    collected = evidence.collect_public_trial(
+        REPOSITORY,
+        88,
+        controller_actor="github-actions[bot]",
+        expected_subject_actor="subject",
+        expected_controller_code_sha=CODE_SHA,
+    )
+    assert collected["public_verification"]["valid"] is True
+    assert collected["configuration"]["block_id"] == "RCL-VAL-001"
+
+
+def test_collector_rejects_unsafe_repository_before_network(monkeypatch):
+    called = False
+
+    def should_not_run(*args, **kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("network should not be reached")
+
+    monkeypatch.setattr(evidence, "_fetch_comments", should_not_run)
+    with pytest.raises(ValueError, match="owner/name"):
+        evidence.collect_public_trial("owner/repo/../../other", 1)
+    assert called is False


### PR DESCRIPTION
## Purpose

Close the engineering gap identified by the Stage 004 construct-validity audit: the effective product configuration **and the exact subject instructions** must be cryptographically recoverable for every auditable RCL trial.

This PR introduces the controller candidate and validation machinery. It **does not lift the execution HOLD** for included `PC-RCL-*` trials. The next gate is a public, permanently excluded `RCL-VAL-001` end-to-end validation from the exact frozen controller commit.

## Configuration and instruction binding

The controller computes a canonical binding from:

- block ID;
- configuration protocol;
- repository;
- full configuration commit SHA;
- repository-relative configuration path;
- SHA-256 of the exact configuration bytes.

The strict configuration record additionally names the repository-relative subject-instruction path and the SHA-256 of its exact bytes. Unknown fields, noncanonical paths, symlinked configuration files, non-UTC timestamps, malformed commits, and unsafe repository identifiers are rejected.

The binding hash is carried in:

- `SAIS_RCL_READY`;
- every HMAC-signed event body;
- commit, probe, and action phase messages;
- both subject forecasts and the diagnosis;
- `SAIS_RCL_SEAL`;
- `SAIS_RCL_REVEAL`.

The hidden 256-bit trial state is generated only after a protocol-closed Forecast0 has echoed the binding hash.

## Dual immutable execution references

The workflow checks out two independent immutable references and verifies both local HEADs before execution:

1. controller code from the dispatched frozen Git ref;
2. product configuration and instructions from an explicit full Git commit.

The new workflow shares the existing ledger concurrency group so the old and new controllers cannot race while pushing to `controller-ledger`.

## Three-source public reconstruction

The collector reconstructs the authoritative record from:

1. public issue comments;
2. exact signed-ledger bytes from the commit named by the reveal;
3. exact configuration **and subject-instruction bytes** from the repository, commit, and paths named by the signed binding.

It verifies Git blob SHA-1, direct byte SHA-256, canonical object hashes, identities, exact source-comment IDs and timestamps, monotonic protocol order, seal-before-reveal, the signed event chain, configuration provenance, instruction provenance, exact block ID, exact configuration commit/path, and exact controller SHA constraints.

## Threat hardening

- validates repository, commit, path, trial ID, actor, block ID, and issue inputs before network access;
- rejects path aliases such as `..`, `.`, repeated separators, backslashes, and control characters;
- selects subject responses by exact IDs sealed in the ledger;
- requires exact forecast and diagnosis field sets, non-empty rationales, and unique required-component lists;
- ignores outsider-authored fake phase prefixes;
- rejects duplicate phases from the frozen controller actor;
- rejects configuration substitution, instruction substitution, binding substitution, cross-source mismatch, malformed base64, ledger mutation, metadata-only hash claims, and post-seal tampering.

## Validation-only block

Adds `RCL-VAL-001`, a continued-conversation infrastructure validation block that is permanently excluded from all behavioral estimates. Its public validation remains `NOT_STARTED` until this candidate passes review, CI, merge, and exact-commit tagging.

Successful validation closes the configuration-binding engineering gate only. Included trials remain on HOLD until the confirmatory analyzer is migrated to the tagged controller, an included-block configuration is frozen, and the prior ambiguity around missing/refused/structurally invalid subject records is resolved without silent exclusion.

## Quality gates

- full suite: `76 passed`
- targeted Ruff `E,F,I` for all new controller/evidence/config files: PASS
- Python compileall: PASS
- Stage 004 freeze remains byte-valid: PASS
- workflow YAML parse: PASS
- JSON Schema validation of the validation configuration: PASS
- direct subject-instruction byte hash: PASS
- diff check: PASS
- both CLI entrypoints: PASS
- secret and absolute-path scan: no findings
- Bandit: no medium/high findings; only expected low-severity notices for fixed-argv, `shell=False` Git subprocess calls

The local Mac exposes Python 3.9, below the project's declared `>=3.11`; authoritative supported-runtime package installation remains delegated to GitHub CI on Python 3.11.

## Incidental correction

Removes one pre-existing duplicate `protocol_version` key in a Stage 002 dictionary. Both values were identical, so this is a static correctness cleanup with no behavior change.

Base: `b4dd52e8cdaeac410ba0a04ee2d90287976d4098`
Head: `26bc9ba4dc5aa9fe7e9e8e5c51241988131e3f99`

Follows #7 and preserves its execution HOLD until the subsequent public-validation and admission-freeze gates succeed.