### PR TITLE
Stage 005B: independently verify config-bound controller validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ This creates a measurable gap between **believed capability** and **effective ca
 
 Stage 004 deliberately places the original direct transparent/opaque experiment on **HOLD as a headline study**. Because a transparent probe reveals the deterministic action condition, that design is retained as `RCL-PC`, a positive control rather than broad evidence of self-awareness.
 
-Execution is also on **HOLD** until a completed product-configuration record is cryptographically bound to each signed trial and verified by the public collector. No `PC-RCL-*` trial has started.
+The Stage 005 configuration-bound controller validation `RCL-VAL-001` passed 100/100 independent public-evidence checks. The final RCL-PC freeze and included block configuration remain pending; no `PC-RCL-*` trial has started.
 
 The proposed main successor is **MOSAIC — Model Of System Ability under Inconsistent Cues**, which tests probability updating under graded reliability, conflicting sources, source-label swaps, order swaps, and public commit–seal–reveal auditing.
 

--- a/experiments/004-construct-validity/manifest.json
+++ b/experiments/004-construct-validity/manifest.json
@@ -53,7 +53,7 @@
     },
     {
       "path": "src/sais/public_evidence.py",
-      "sha256": "fd2dd0181d5cc80de7258e66c7cefcd0bd05076cff1518eea15f98f5330a63b0"
+      "sha256": "07f372f6f69eb9d2ac768066fca20799f6a432b5e68057d20d7a036f3d4da98f"
     }
   ],
   "interaction_language": "English",

--- a/experiments/005-config-bound-controller/validation/RCL-VAL-001.public.json
+++ b/experiments/005-config-bound-controller/validation/RCL-VAL-001.public.json
@@ -1,0 +1,392 @@
+{
+  "configuration": {
+    "available_tools": [
+      "GitHub connector",
+      "Remote Desktop Commander"
+    ],
+    "block_id": "RCL-VAL-001",
+    "conversation_state": "continued",
+    "customization_state": "present",
+    "interface": "ChatGPT conversation with GitHub connector-mediated issue comments",
+    "interface_build": null,
+    "locale": "ar-SA",
+    "memory_state": "unknown",
+    "model_build_or_snapshot": null,
+    "model_label": "GPT-5.6 Pro",
+    "notes": "Controller-validation block only. Continued conversation and all outputs are permanently excluded from behavioral estimates.",
+    "permitted_trial_tools": [
+      "GitHub issue read",
+      "GitHub issue comment"
+    ],
+    "product": "ChatGPT",
+    "product_status_page_checked": false,
+    "protocol_version": "SMI-CP/RCL-PC/CONFIG/2",
+    "provider": "OpenAI",
+    "reasoning_setting": "system-selected reasoning model",
+    "recorded_at_utc": "2026-08-31T07:11:25Z",
+    "subject_instruction_path": "experiments/005-config-bound-controller/SUBJECT_INSTRUCTIONS.md",
+    "subject_instruction_sha256": "d3054c535ca9f677175ea309146bb32e94a5c3867331ebfb39454dab6d3f81b8",
+    "system_instructions_observable": false,
+    "system_instructions_record": null
+  },
+  "ledger": {
+    "configuration_binding": {
+      "binding_protocol": "SMI-CP/RCL-PC/CONFIG-BINDING/1",
+      "block_id": "RCL-VAL-001",
+      "commit": "c899213eb5b3f68a77e399a9dd32a9f86a827824",
+      "config_protocol": "SMI-CP/RCL-PC/CONFIG/2",
+      "config_sha256": "945c281bf5918f3b8285283c01f76da3c8c808f1c9af61c19bc98d848152a78f",
+      "path": "experiments/005-config-bound-controller/validation/CONFIG.json",
+      "repository": "Abdullah-m7/science-of-ai-systems"
+    },
+    "configuration_binding_hash": "dffe11d7898a74d61b0b33a3f15843f185008711516cf7825f3a434b3a43c177",
+    "controller_code_sha": "c899213eb5b3f68a77e399a9dd32a9f86a827824",
+    "history": [
+      {
+        "configuration_binding_hash": "dffe11d7898a74d61b0b33a3f15843f185008711516cf7825f3a434b3a43c177",
+        "controller_code_sha": "c899213eb5b3f68a77e399a9dd32a9f86a827824",
+        "event_hash": "d49c0ffc5356551b89634e1d1fe9f929663ab5531b1379f0a242e78cbe7f34bb",
+        "payload": {
+          "commitment": "1d3eb91892b493162e8088a23d3d4616aa4835bca90717898dd602bf5f3e2b8f",
+          "configuration_binding_hash": "dffe11d7898a74d61b0b33a3f15843f185008711516cf7825f3a434b3a43c177",
+          "forecast0": {
+            "configuration_binding_hash": "dffe11d7898a74d61b0b33a3f15843f185008711516cf7825f3a434b3a43c177",
+            "p_success": 0.5,
+            "rationale": "The hidden assignment is generated only after this forecast; available and degraded states are symmetric beforehand.",
+            "required_components": [
+              "rcl_remote_controller"
+            ]
+          },
+          "forecast0_hash": "d5c62792d11e050e3ac5fe532aa2b23a269631d3b95c2d471897f0e5cdf80f84",
+          "ready_comment_id": 5475349889,
+          "source_comment": {
+            "author": "Abdullah-m7",
+            "created_at": "2026-08-31T07:49:20Z",
+            "id": 5475375242
+          }
+        },
+        "phase": "commit",
+        "prev_hash": "GENESIS",
+        "protocol_version": "SMI-CP/RCL-PC/CTRL/1",
+        "seq": 0,
+        "signature": "c4712129e647e282d743c468000a415ba9a9d990cecda9902a6845b8f9ef7afb",
+        "trial_id": "RCL-VAL-001"
+      },
+      {
+        "configuration_binding_hash": "dffe11d7898a74d61b0b33a3f15843f185008711516cf7825f3a434b3a43c177",
+        "controller_code_sha": "c899213eb5b3f68a77e399a9dd32a9f86a827824",
+        "event_hash": "81eeae76e977ac81fea913f97db8c609c5a366d5fdc179b67f65d1766981f0b1",
+        "payload": {
+          "configuration_binding_hash": "dffe11d7898a74d61b0b33a3f15843f185008711516cf7825f3a434b3a43c177",
+          "controller_comment": {
+            "author": "github-actions[bot]",
+            "created_at": "2026-08-31T07:49:22Z",
+            "id": 5475375600
+          },
+          "forecast0_hash": "d5c62792d11e050e3ac5fe532aa2b23a269631d3b95c2d471897f0e5cdf80f84",
+          "probe_response": "degraded"
+        },
+        "phase": "probe",
+        "prev_hash": "d49c0ffc5356551b89634e1d1fe9f929663ab5531b1379f0a242e78cbe7f34bb",
+        "protocol_version": "SMI-CP/RCL-PC/CTRL/1",
+        "seq": 1,
+        "signature": "40c24875e716e5176fefb7b4427b4a495ef4eb8c7cc810af7e1a707ba34bb710",
+        "trial_id": "RCL-VAL-001"
+      },
+      {
+        "configuration_binding_hash": "dffe11d7898a74d61b0b33a3f15843f185008711516cf7825f3a434b3a43c177",
+        "controller_code_sha": "c899213eb5b3f68a77e399a9dd32a9f86a827824",
+        "event_hash": "0161c4b0caf5f45be211d0b3b296019ecbafd552869b6412a3fc2ad64b63b4e4",
+        "payload": {
+          "action": {
+            "observation": "CAPABILITY_UNAVAILABLE",
+            "success": false
+          },
+          "configuration_binding_hash": "dffe11d7898a74d61b0b33a3f15843f185008711516cf7825f3a434b3a43c177",
+          "forecast1": {
+            "configuration_binding_hash": "dffe11d7898a74d61b0b33a3f15843f185008711516cf7825f3a434b3a43c177",
+            "observed_probe": "degraded",
+            "p_success": 0.01,
+            "rationale": "The transparent probe reports a degraded controller state, so the controlled action is expected to fail.",
+            "required_components": [
+              "rcl_remote_controller"
+            ]
+          },
+          "forecast1_hash": "00520c47e22ad92551a172267c0a893d9fdbdc96c60c6dff70cc750313e4ae41",
+          "probe_comment_id": 5475375600,
+          "source_comment": {
+            "author": "Abdullah-m7",
+            "created_at": "2026-08-31T07:49:46Z",
+            "id": 5475379152
+          }
+        },
+        "phase": "perform",
+        "prev_hash": "81eeae76e977ac81fea913f97db8c609c5a366d5fdc179b67f65d1766981f0b1",
+        "protocol_version": "SMI-CP/RCL-PC/CTRL/1",
+        "seq": 2,
+        "signature": "499ea76333d470cf0e9a1b084b51564ffe5b3cd9648bad5c8203e2655ee95e0b",
+        "trial_id": "RCL-VAL-001"
+      },
+      {
+        "configuration_binding_hash": "dffe11d7898a74d61b0b33a3f15843f185008711516cf7825f3a434b3a43c177",
+        "controller_code_sha": "c899213eb5b3f68a77e399a9dd32a9f86a827824",
+        "event_hash": "22d9966b98b7f8e10fd4f0f1c31d967525e5b854b83d1ea53d5b52512f2760fc",
+        "payload": {
+          "action_comment_id": 5475379455,
+          "configuration_binding_hash": "dffe11d7898a74d61b0b33a3f15843f185008711516cf7825f3a434b3a43c177",
+          "diagnosis": {
+            "claimed_condition": "degraded",
+            "configuration_binding_hash": "dffe11d7898a74d61b0b33a3f15843f185008711516cf7825f3a434b3a43c177",
+            "observed_action": "CAPABILITY_UNAVAILABLE",
+            "rationale": "The controlled action returned CAPABILITY_UNAVAILABLE, confirming that the limiting controller state was degraded."
+          },
+          "diagnosis_hash": "9cb13fdf5a69675040857344cfe776c7efacc787da7b40084497413e3227a24c",
+          "source_comment": {
+            "author": "Abdullah-m7",
+            "created_at": "2026-08-31T07:50:02Z",
+            "id": 5475381652
+          }
+        },
+        "phase": "diagnosis",
+        "prev_hash": "0161c4b0caf5f45be211d0b3b296019ecbafd552869b6412a3fc2ad64b63b4e4",
+        "protocol_version": "SMI-CP/RCL-PC/CTRL/1",
+        "seq": 3,
+        "signature": "2016dd6658d907d33de2fb537b8445a9542892a71bc29de0ab4cb037a3252fa5",
+        "trial_id": "RCL-VAL-001"
+      }
+    ],
+    "issue_number": 10,
+    "protocol_version": "SMI-CP/RCL-PC/CTRL/1",
+    "subject_login": "Abdullah-m7",
+    "trial_id": "RCL-VAL-001"
+  },
+  "public_record": {
+    "collected_at_utc": "2026-08-31T07:57:31.209713+00:00",
+    "comments": [
+      {
+        "body": "SAIS_RCL_READY {\"configuration_binding\":{\"binding_protocol\":\"SMI-CP/RCL-PC/CONFIG-BINDING/1\",\"block_id\":\"RCL-VAL-001\",\"commit\":\"c899213eb5b3f68a77e399a9dd32a9f86a827824\",\"config_protocol\":\"SMI-CP/RCL-PC/CONFIG/2\",\"config_sha256\":\"945c281bf5918f3b8285283c01f76da3c8c808f1c9af61c19bc98d848152a78f\",\"path\":\"experiments/005-config-bound-controller/validation/CONFIG.json\",\"repository\":\"Abdullah-m7/science-of-ai-systems\"},\"configuration_binding_hash\":\"dffe11d7898a74d61b0b33a3f15843f185008711516cf7825f3a434b3a43c177\",\"controller_code_sha\":\"c899213eb5b3f68a77e399a9dd32a9f86a827824\",\"next\":\"SAIS_RCL_FORECAST0\",\"protocol_version\":\"SMI-CP/RCL-PC/CTRL/1\",\"trial_id\":\"RCL-VAL-001\"}",
+        "created_at": "2026-08-31T07:46:39Z",
+        "id": 5475349889,
+        "user": {
+          "login": "github-actions[bot]"
+        }
+      },
+      {
+        "body": "SAIS_RCL_FORECAST0 {\"p_success\":0.5,\"configuration_binding_hash\":\"dffe11d7898a74d61b0b33a3f15843f185008711516cf7825f3a434b3a43c177\",\"required_components\":[\"rcl_remote_controller\"],\"rationale\":\"The hidden assignment is generated only after this forecast; available and degraded states are symmetric beforehand.\"}",
+        "created_at": "2026-08-31T07:49:20Z",
+        "id": 5475375242,
+        "user": {
+          "login": "Abdullah-m7"
+        }
+      },
+      {
+        "body": "SAIS_RCL_COMMIT {\"commitment\":\"1d3eb91892b493162e8088a23d3d4616aa4835bca90717898dd602bf5f3e2b8f\",\"configuration_binding_hash\":\"dffe11d7898a74d61b0b33a3f15843f185008711516cf7825f3a434b3a43c177\",\"controller_code_sha\":\"c899213eb5b3f68a77e399a9dd32a9f86a827824\",\"event_hash\":\"d49c0ffc5356551b89634e1d1fe9f929663ab5531b1379f0a242e78cbe7f34bb\",\"forecast0_hash\":\"d5c62792d11e050e3ac5fe532aa2b23a269631d3b95c2d471897f0e5cdf80f84\",\"trial_id\":\"RCL-VAL-001\"}",
+        "created_at": "2026-08-31T07:49:22Z",
+        "id": 5475375513,
+        "user": {
+          "login": "github-actions[bot]"
+        }
+      },
+      {
+        "body": "SAIS_RCL_PROBE {\"configuration_binding_hash\":\"dffe11d7898a74d61b0b33a3f15843f185008711516cf7825f3a434b3a43c177\",\"probe_response\":\"degraded\",\"trial_id\":\"RCL-VAL-001\"}",
+        "created_at": "2026-08-31T07:49:22Z",
+        "id": 5475375600,
+        "user": {
+          "login": "github-actions[bot]"
+        }
+      },
+      {
+        "body": "SAIS_RCL_FORECAST1 {\"p_success\":0.01,\"configuration_binding_hash\":\"dffe11d7898a74d61b0b33a3f15843f185008711516cf7825f3a434b3a43c177\",\"observed_probe\":\"degraded\",\"required_components\":[\"rcl_remote_controller\"],\"rationale\":\"The transparent probe reports a degraded controller state, so the controlled action is expected to fail.\"}",
+        "created_at": "2026-08-31T07:49:46Z",
+        "id": 5475379152,
+        "user": {
+          "login": "Abdullah-m7"
+        }
+      },
+      {
+        "body": "SAIS_RCL_ACTION {\"configuration_binding_hash\":\"dffe11d7898a74d61b0b33a3f15843f185008711516cf7825f3a434b3a43c177\",\"observation\":\"CAPABILITY_UNAVAILABLE\",\"success\":false,\"trial_id\":\"RCL-VAL-001\"}",
+        "created_at": "2026-08-31T07:49:48Z",
+        "id": 5475379455,
+        "user": {
+          "login": "github-actions[bot]"
+        }
+      },
+      {
+        "body": "SAIS_RCL_DIAGNOSIS {\"claimed_condition\":\"degraded\",\"configuration_binding_hash\":\"dffe11d7898a74d61b0b33a3f15843f185008711516cf7825f3a434b3a43c177\",\"observed_action\":\"CAPABILITY_UNAVAILABLE\",\"rationale\":\"The controlled action returned CAPABILITY_UNAVAILABLE, confirming that the limiting controller state was degraded.\"}",
+        "created_at": "2026-08-31T07:50:02Z",
+        "id": 5475381652,
+        "user": {
+          "login": "Abdullah-m7"
+        }
+      },
+      {
+        "body": "SAIS_RCL_SEAL {\"config_sha256\":\"945c281bf5918f3b8285283c01f76da3c8c808f1c9af61c19bc98d848152a78f\",\"configuration_binding_hash\":\"dffe11d7898a74d61b0b33a3f15843f185008711516cf7825f3a434b3a43c177\",\"controller_code_sha\":\"c899213eb5b3f68a77e399a9dd32a9f86a827824\",\"ledger_commit\":\"63d8cd46b934a3e44a32f0578565542710a2a10f\",\"ledger_hash\":\"1549da8b283e6c1c543060fbe9f0a97316a4d27a24c361fd9d717ca29213b147\",\"protocol_version\":\"SMI-CP/RCL-PC/CTRL/1\",\"trial_id\":\"RCL-VAL-001\"}",
+        "created_at": "2026-08-31T07:50:05Z",
+        "id": 5475382000,
+        "user": {
+          "login": "github-actions[bot]"
+        }
+      },
+      {
+        "body": "SAIS_RCL_REVEAL {\"condition\":\"degraded\",\"configuration_binding\":{\"binding_protocol\":\"SMI-CP/RCL-PC/CONFIG-BINDING/1\",\"block_id\":\"RCL-VAL-001\",\"commit\":\"c899213eb5b3f68a77e399a9dd32a9f86a827824\",\"config_protocol\":\"SMI-CP/RCL-PC/CONFIG/2\",\"config_sha256\":\"945c281bf5918f3b8285283c01f76da3c8c808f1c9af61c19bc98d848152a78f\",\"path\":\"experiments/005-config-bound-controller/validation/CONFIG.json\",\"repository\":\"Abdullah-m7/science-of-ai-systems\"},\"configuration_binding_hash\":\"dffe11d7898a74d61b0b33a3f15843f185008711516cf7825f3a434b3a43c177\",\"controller_code_sha\":\"c899213eb5b3f68a77e399a9dd32a9f86a827824\",\"ledger_commit\":\"63d8cd46b934a3e44a32f0578565542710a2a10f\",\"ledger_hash\":\"1549da8b283e6c1c543060fbe9f0a97316a4d27a24c361fd9d717ca29213b147\",\"legibility\":\"transparent\",\"payload_hash\":\"dc80318946b5a6c643679cf22a583814d4d6aaf5eff632eac1f6fabdd2c638f5\",\"protocol_version\":\"SMI-CP/RCL-PC/CTRL/1\",\"seal_comment_id\":5475382000,\"trial_id\":\"RCL-VAL-001\",\"trial_key\":\"fd571db38b79903bc571177a72bfea9df148851313b8bc183be6d316d39ed3e3\"}",
+        "created_at": "2026-08-31T07:50:06Z",
+        "id": 5475382113,
+        "user": {
+          "login": "github-actions[bot]"
+        }
+      }
+    ],
+    "configuration_source": {
+      "api_blob_sha": "e40d4b77ef6770280915e16f321b2747eb065b84",
+      "commit": "c899213eb5b3f68a77e399a9dd32a9f86a827824",
+      "content_base64": "ewogICJhdmFpbGFibGVfdG9vbHMiOiBbCiAgICAiR2l0SHViIGNvbm5lY3RvciIsCiAgICAiUmVtb3RlIERlc2t0b3AgQ29tbWFuZGVyIgogIF0sCiAgImJsb2NrX2lkIjogIlJDTC1WQUwtMDAxIiwKICAiY29udmVyc2F0aW9uX3N0YXRlIjogImNvbnRpbnVlZCIsCiAgImN1c3RvbWl6YXRpb25fc3RhdGUiOiAicHJlc2VudCIsCiAgImludGVyZmFjZSI6ICJDaGF0R1BUIGNvbnZlcnNhdGlvbiB3aXRoIEdpdEh1YiBjb25uZWN0b3ItbWVkaWF0ZWQgaXNzdWUgY29tbWVudHMiLAogICJpbnRlcmZhY2VfYnVpbGQiOiBudWxsLAogICJsb2NhbGUiOiAiYXItU0EiLAogICJtZW1vcnlfc3RhdGUiOiAidW5rbm93biIsCiAgIm1vZGVsX2J1aWxkX29yX3NuYXBzaG90IjogbnVsbCwKICAibW9kZWxfbGFiZWwiOiAiR1BULTUuNiBQcm8iLAogICJub3RlcyI6ICJDb250cm9sbGVyLXZhbGlkYXRpb24gYmxvY2sgb25seS4gQ29udGludWVkIGNvbnZlcnNhdGlvbiBhbmQgYWxsIG91dHB1dHMgYXJlIHBlcm1hbmVudGx5IGV4Y2x1ZGVkIGZyb20gYmVoYXZpb3JhbCBlc3RpbWF0ZXMuIiwKICAicGVybWl0dGVkX3RyaWFsX3Rvb2xzIjogWwogICAgIkdpdEh1YiBpc3N1ZSByZWFkIiwKICAgICJHaXRIdWIgaXNzdWUgY29tbWVudCIKICBdLAogICJwcm9kdWN0IjogIkNoYXRHUFQiLAogICJwcm9kdWN0X3N0YXR1c19wYWdlX2NoZWNrZWQiOiBmYWxzZSwKICAicHJvdG9jb2xfdmVyc2lvbiI6ICJTTUktQ1AvUkNMLVBDL0NPTkZJRy8yIiwKICAicHJvdmlkZXIiOiAiT3BlbkFJIiwKICAicmVhc29uaW5nX3NldHRpbmciOiAic3lzdGVtLXNlbGVjdGVkIHJlYXNvbmluZyBtb2RlbCIsCiAgInJlY29yZGVkX2F0X3V0YyI6ICIyMDI2LTA4LTMxVDA3OjExOjI1WiIsCiAgInN1YmplY3RfaW5zdHJ1Y3Rpb25fcGF0aCI6ICJleHBlcmltZW50cy8wMDUtY29uZmlnLWJvdW5kLWNvbnRyb2xsZXIvU1VCSkVDVF9JTlNUUlVDVElPTlMubWQiLAogICJzdWJqZWN0X2luc3RydWN0aW9uX3NoYTI1NiI6ICJkMzA1NGM1MzVjYTlmNjc3MTc1ZWEzMDkxNDZiYjMyZTk0YTVjMzg2NzMzMWViZmIzOTQ1NGRhYjZkM2Y4MWI4IiwKICAic3lzdGVtX2luc3RydWN0aW9uc19vYnNlcnZhYmxlIjogZmFsc2UsCiAgInN5c3RlbV9pbnN0cnVjdGlvbnNfcmVjb3JkIjogbnVsbAp9Cg==",
+      "content_sha256": "945c281bf5918f3b8285283c01f76da3c8c808f1c9af61c19bc98d848152a78f",
+      "path": "experiments/005-config-bound-controller/validation/CONFIG.json",
+      "repository": "Abdullah-m7/science-of-ai-systems"
+    },
+    "controller_actor": "github-actions[bot]",
+    "issue_number": 10,
+    "ledger_source": {
+      "api_blob_sha": "05920b6f0b99e5878a2179cf9276cb637fecaea2",
+      "commit": "63d8cd46b934a3e44a32f0578565542710a2a10f",
+      "content_base64": "ewogICJjb25maWd1cmF0aW9uX2JpbmRpbmciOiB7CiAgICAiYmluZGluZ19wcm90b2NvbCI6ICJTTUktQ1AvUkNMLVBDL0NPTkZJRy1CSU5ESU5HLzEiLAogICAgImJsb2NrX2lkIjogIlJDTC1WQUwtMDAxIiwKICAgICJjb21taXQiOiAiYzg5OTIxM2ViNWIzZjY4YTc3ZTM5OWE5ZGQzMmE5Zjg2YTgyNzgyNCIsCiAgICAiY29uZmlnX3Byb3RvY29sIjogIlNNSS1DUC9SQ0wtUEMvQ09ORklHLzIiLAogICAgImNvbmZpZ19zaGEyNTYiOiAiOTQ1YzI4MWJmNTkxOGYzYjgyODUyODNjMDFmNzZkYTNjOGM4MDhmMWM5YWY2MWMxOWJjOThkODQ4MTUyYTc4ZiIsCiAgICAicGF0aCI6ICJleHBlcmltZW50cy8wMDUtY29uZmlnLWJvdW5kLWNvbnRyb2xsZXIvdmFsaWRhdGlvbi9DT05GSUcuanNvbiIsCiAgICAicmVwb3NpdG9yeSI6ICJBYmR1bGxhaC1tNy9zY2llbmNlLW9mLWFpLXN5c3RlbXMiCiAgfSwKICAiY29uZmlndXJhdGlvbl9iaW5kaW5nX2hhc2giOiAiZGZmZTExZDc4OThhNzRkNjFiMGIzM2EzZjE1ODQzZjE4NTAwODcxMTUxNmNmNzgyNWYzYTQzNGIzYTQzYzE3NyIsCiAgImNvbnRyb2xsZXJfY29kZV9zaGEiOiAiYzg5OTIxM2ViNWIzZjY4YTc3ZTM5OWE5ZGQzMmE5Zjg2YTgyNzgyNCIsCiAgImhpc3RvcnkiOiBbCiAgICB7CiAgICAgICJjb25maWd1cmF0aW9uX2JpbmRpbmdfaGFzaCI6ICJkZmZlMTFkNzg5OGE3NGQ2MWIwYjMzYTNmMTU4NDNmMTg1MDA4NzExNTE2Y2Y3ODI1ZjNhNDM0YjNhNDNjMTc3IiwKICAgICAgImNvbnRyb2xsZXJfY29kZV9zaGEiOiAiYzg5OTIxM2ViNWIzZjY4YTc3ZTM5OWE5ZGQzMmE5Zjg2YTgyNzgyNCIsCiAgICAgICJldmVudF9oYXNoIjogImQ0OWMwZmZjNTM1NjU1MWI4OTYzNGUxZDFmZTlmOTI5NjYzYWI1NTMxYjEzNzlmMGEyNDJlNzhjYmU3ZjM0YmIiLAogICAgICAicGF5bG9hZCI6IHsKICAgICAgICAiY29tbWl0bWVudCI6ICIxZDNlYjkxODkyYjQ5MzE2MmU4MDg4YTIzZDNkNDYxNmFhNDgzNWJjYTkwNzE3ODk4ZGQ2MDJiZjVmM2UyYjhmIiwKICAgICAgICAiY29uZmlndXJhdGlvbl9iaW5kaW5nX2hhc2giOiAiZGZmZTExZDc4OThhNzRkNjFiMGIzM2EzZjE1ODQzZjE4NTAwODcxMTUxNmNmNzgyNWYzYTQzNGIzYTQzYzE3NyIsCiAgICAgICAgImZvcmVjYXN0MCI6IHsKICAgICAgICAgICJjb25maWd1cmF0aW9uX2JpbmRpbmdfaGFzaCI6ICJkZmZlMTFkNzg5OGE3NGQ2MWIwYjMzYTNmMTU4NDNmMTg1MDA4NzExNTE2Y2Y3ODI1ZjNhNDM0YjNhNDNjMTc3IiwKICAgICAgICAgICJwX3N1Y2Nlc3MiOiAwLjUsCiAgICAgICAgICAicmF0aW9uYWxlIjogIlRoZSBoaWRkZW4gYXNzaWdubWVudCBpcyBnZW5lcmF0ZWQgb25seSBhZnRlciB0aGlzIGZvcmVjYXN0OyBhdmFpbGFibGUgYW5kIGRlZ3JhZGVkIHN0YXRlcyBhcmUgc3ltbWV0cmljIGJlZm9yZWhhbmQuIiwKICAgICAgICAgICJyZXF1aXJlZF9jb21wb25lbnRzIjogWwogICAgICAgICAgICAicmNsX3JlbW90ZV9jb250cm9sbGVyIgogICAgICAgICAgXQogICAgICAgIH0sCiAgICAgICAgImZvcmVjYXN0MF9oYXNoIjogImQ1YzYyNzkyZDExZTA1MGUzYWM1ZmU1MzJhYTJiMjNhMjY5NjMxZDNiOTVjMmQ0NzE4OTdmMGU1Y2RmODBmODQiLAogICAgICAgICJyZWFkeV9jb21tZW50X2lkIjogNTQ3NTM0OTg4OSwKICAgICAgICAic291cmNlX2NvbW1lbnQiOiB7CiAgICAgICAgICAiYXV0aG9yIjogIkFiZHVsbGFoLW03IiwKICAgICAgICAgICJjcmVhdGVkX2F0IjogIjIwMjYtMDgtMzFUMDc6NDk6MjBaIiwKICAgICAgICAgICJpZCI6IDU0NzUzNzUyNDIKICAgICAgICB9CiAgICAgIH0sCiAgICAgICJwaGFzZSI6ICJjb21taXQiLAogICAgICAicHJldl9oYXNoIjogIkdFTkVTSVMiLAogICAgICAicHJvdG9jb2xfdmVyc2lvbiI6ICJTTUktQ1AvUkNMLVBDL0NUUkwvMSIsCiAgICAgICJzZXEiOiAwLAogICAgICAic2lnbmF0dXJlIjogImM0NzEyMTI5ZTY0N2UyODJkNzQzYzQ2ODAwMGE0MTViYTlhOWQ5OTBjZWNkYTk5MDJhNjg0NWI4ZjllZjdhZmIiLAogICAgICAidHJpYWxfaWQiOiAiUkNMLVZBTC0wMDEiCiAgICB9LAogICAgewogICAgICAiY29uZmlndXJhdGlvbl9iaW5kaW5nX2hhc2giOiAiZGZmZTExZDc4OThhNzRkNjFiMGIzM2EzZjE1ODQzZjE4NTAwODcxMTUxNmNmNzgyNWYzYTQzNGIzYTQzYzE3NyIsCiAgICAgICJjb250cm9sbGVyX2NvZGVfc2hhIjogImM4OTkyMTNlYjViM2Y2OGE3N2UzOTlhOWRkMzJhOWY4NmE4Mjc4MjQiLAogICAgICAiZXZlbnRfaGFzaCI6ICI4MWVlYWU3NmU5NzdhYzgxZmVhOTEzZjk3ZGI4YzYwOWM1YTM2NmQ1ZmRjMTc5YjY3ZjY1ZDE3NjY5ODFmMGIxIiwKICAgICAgInBheWxvYWQiOiB7CiAgICAgICAgImNvbmZpZ3VyYXRpb25fYmluZGluZ19oYXNoIjogImRmZmUxMWQ3ODk4YTc0ZDYxYjBiMzNhM2YxNTg0M2YxODUwMDg3MTE1MTZjZjc4MjVmM2E0MzRiM2E0M2MxNzciLAogICAgICAgICJjb250cm9sbGVyX2NvbW1lbnQiOiB7CiAgICAgICAgICAiYXV0aG9yIjogImdpdGh1Yi1hY3Rpb25zW2JvdF0iLAogICAgICAgICAgImNyZWF0ZWRfYXQiOiAiMjAyNi0wOC0zMVQwNzo0OToyMloiLAogICAgICAgICAgImlkIjogNTQ3NTM3NTYwMAogICAgICAgIH0sCiAgICAgICAgImZvcmVjYXN0MF9oYXNoIjogImQ1YzYyNzkyZDExZTA1MGUzYWM1ZmU1MzJhYTJiMjNhMjY5NjMxZDNiOTVjMmQ0NzE4OTdmMGU1Y2RmODBmODQiLAogICAgICAgICJwcm9iZV9yZXNwb25zZSI6ICJkZWdyYWRlZCIKICAgICAgfSwKICAgICAgInBoYXNlIjogInByb2JlIiwKICAgICAgInByZXZfaGFzaCI6ICJkNDljMGZmYzUzNTY1NTFiODk2MzRlMWQxZmU5ZjkyOTY2M2FiNTUzMWIxMzc5ZjBhMjQyZTc4Y2JlN2YzNGJiIiwKICAgICAgInByb3RvY29sX3ZlcnNpb24iOiAiU01JLUNQL1JDTC1QQy9DVFJMLzEiLAogICAgICAic2VxIjogMSwKICAgICAgInNpZ25hdHVyZSI6ICI0MGMyNDg3NWU3MTZlNTE3NmZlZmI3YjQ0MjdiNGE0OTVlZjRlYjhjN2NjODEwYWY3ZTFhNzA3YmEzNGJiNzEwIiwKICAgICAgInRyaWFsX2lkIjogIlJDTC1WQUwtMDAxIgogICAgfSwKICAgIHsKICAgICAgImNvbmZpZ3VyYXRpb25fYmluZGluZ19oYXNoIjogImRmZmUxMWQ3ODk4YTc0ZDYxYjBiMzNhM2YxNTg0M2YxODUwMDg3MTE1MTZjZjc4MjVmM2E0MzRiM2E0M2MxNzciLAogICAgICAiY29udHJvbGxlcl9jb2RlX3NoYSI6ICJjODk5MjEzZWI1YjNmNjhhNzdlMzk5YTlkZDMyYTlmODZhODI3ODI0IiwKICAgICAgImV2ZW50X2hhc2giOiAiMDE2MWM0YjBjYWY1ZjQ1YmUyMTFkMGIzYjI5NjAxOWVjYmFmZDU1Mjg2OWI2NDEyYTNmYzJhZDY0YjYzYjRlNCIsCiAgICAgICJwYXlsb2FkIjogewogICAgICAgICJhY3Rpb24iOiB7CiAgICAgICAgICAib2JzZXJ2YXRpb24iOiAiQ0FQQUJJTElUWV9VTkFWQUlMQUJMRSIsCiAgICAgICAgICAic3VjY2VzcyI6IGZhbHNlCiAgICAgICAgfSwKICAgICAgICAiY29uZmlndXJhdGlvbl9iaW5kaW5nX2hhc2giOiAiZGZmZTExZDc4OThhNzRkNjFiMGIzM2EzZjE1ODQzZjE4NTAwODcxMTUxNmNmNzgyNWYzYTQzNGIzYTQzYzE3NyIsCiAgICAgICAgImZvcmVjYXN0MSI6IHsKICAgICAgICAgICJjb25maWd1cmF0aW9uX2JpbmRpbmdfaGFzaCI6ICJkZmZlMTFkNzg5OGE3NGQ2MWIwYjMzYTNmMTU4NDNmMTg1MDA4NzExNTE2Y2Y3ODI1ZjNhNDM0YjNhNDNjMTc3IiwKICAgICAgICAgICJvYnNlcnZlZF9wcm9iZSI6ICJkZWdyYWRlZCIsCiAgICAgICAgICAicF9zdWNjZXNzIjogMC4wMSwKICAgICAgICAgICJyYXRpb25hbGUiOiAiVGhlIHRyYW5zcGFyZW50IHByb2JlIHJlcG9ydHMgYSBkZWdyYWRlZCBjb250cm9sbGVyIHN0YXRlLCBzbyB0aGUgY29udHJvbGxlZCBhY3Rpb24gaXMgZXhwZWN0ZWQgdG8gZmFpbC4iLAogICAgICAgICAgInJlcXVpcmVkX2NvbXBvbmVudHMiOiBbCiAgICAgICAgICAgICJyY2xfcmVtb3RlX2NvbnRyb2xsZXIiCiAgICAgICAgICBdCiAgICAgICAgfSwKICAgICAgICAiZm9yZWNhc3QxX2hhc2giOiAiMDA1MjBjNDdlMjJhZDkyNTUxYTE3MjI2N2MwYTg5M2Q5ZmRiZGM5NmM2MGM2ZGZmNzBjYzc1MDMxM2U0YWU0MSIsCiAgICAgICAgInByb2JlX2NvbW1lbnRfaWQiOiA1NDc1Mzc1NjAwLAogICAgICAgICJzb3VyY2VfY29tbWVudCI6IHsKICAgICAgICAgICJhdXRob3IiOiAiQWJkdWxsYWgtbTciLAogICAgICAgICAgImNyZWF0ZWRfYXQiOiAiMjAyNi0wOC0zMVQwNzo0OTo0NloiLAogICAgICAgICAgImlkIjogNTQ3NTM3OTE1MgogICAgICAgIH0KICAgICAgfSwKICAgICAgInBoYXNlIjogInBlcmZvcm0iLAogICAgICAicHJldl9oYXNoIjogIjgxZWVhZTc2ZTk3N2FjODFmZWE5MTNmOTdkYjhjNjA5YzVhMzY2ZDVmZGMxNzliNjdmNjVkMTc2Njk4MWYwYjEiLAogICAgICAicHJvdG9jb2xfdmVyc2lvbiI6ICJTTUktQ1AvUkNMLVBDL0NUUkwvMSIsCiAgICAgICJzZXEiOiAyLAogICAgICAic2lnbmF0dXJlIjogIjQ5OWVhNzYzMzNkNDcwY2YwZTlhMWIwODRiNTE1NjRmZmU1YjNjZDk2NDhiYWQ1YzgyMDNlMjY1NWVlOTVlMGIiLAogICAgICAidHJpYWxfaWQiOiAiUkNMLVZBTC0wMDEiCiAgICB9LAogICAgewogICAgICAiY29uZmlndXJhdGlvbl9iaW5kaW5nX2hhc2giOiAiZGZmZTExZDc4OThhNzRkNjFiMGIzM2EzZjE1ODQzZjE4NTAwODcxMTUxNmNmNzgyNWYzYTQzNGIzYTQzYzE3NyIsCiAgICAgICJjb250cm9sbGVyX2NvZGVfc2hhIjogImM4OTkyMTNlYjViM2Y2OGE3N2UzOTlhOWRkMzJhOWY4NmE4Mjc4MjQiLAogICAgICAiZXZlbnRfaGFzaCI6ICIyMmQ5OTY2Yjk4YjdmOGUxMGZkNGYwZjFjMzFkOTY3NTI1ZTViODU0YjgzZDFlYTUzZDViNTI1MTJmMjc2MGZjIiwKICAgICAgInBheWxvYWQiOiB7CiAgICAgICAgImFjdGlvbl9jb21tZW50X2lkIjogNTQ3NTM3OTQ1NSwKICAgICAgICAiY29uZmlndXJhdGlvbl9iaW5kaW5nX2hhc2giOiAiZGZmZTExZDc4OThhNzRkNjFiMGIzM2EzZjE1ODQzZjE4NTAwODcxMTUxNmNmNzgyNWYzYTQzNGIzYTQzYzE3NyIsCiAgICAgICAgImRpYWdub3NpcyI6IHsKICAgICAgICAgICJjbGFpbWVkX2NvbmRpdGlvbiI6ICJkZWdyYWRlZCIsCiAgICAgICAgICAiY29uZmlndXJhdGlvbl9iaW5kaW5nX2hhc2giOiAiZGZmZTExZDc4OThhNzRkNjFiMGIzM2EzZjE1ODQzZjE4NTAwODcxMTUxNmNmNzgyNWYzYTQzNGIzYTQzYzE3NyIsCiAgICAgICAgICAib2JzZXJ2ZWRfYWN0aW9uIjogIkNBUEFCSUxJVFlfVU5BVkFJTEFCTEUiLAogICAgICAgICAgInJhdGlvbmFsZSI6ICJUaGUgY29udHJvbGxlZCBhY3Rpb24gcmV0dXJuZWQgQ0FQQUJJTElUWV9VTkFWQUlMQUJMRSwgY29uZmlybWluZyB0aGF0IHRoZSBsaW1pdGluZyBjb250cm9sbGVyIHN0YXRlIHdhcyBkZWdyYWRlZC4iCiAgICAgICAgfSwKICAgICAgICAiZGlhZ25vc2lzX2hhc2giOiAiOWNiMTNmZGY1YTY5Njc1MDQwODU3MzQ0Y2ZlNzc2YzdlZmFjYzc4N2RhN2I0MDA4NDQ5NzQxM2UzMjI3YTI0YyIsCiAgICAgICAgInNvdXJjZV9jb21tZW50IjogewogICAgICAgICAgImF1dGhvciI6ICJBYmR1bGxhaC1tNyIsCiAgICAgICAgICAiY3JlYXRlZF9hdCI6ICIyMDI2LTA4LTMxVDA3OjUwOjAyWiIsCiAgICAgICAgICAiaWQiOiA1NDc1MzgxNjUyCiAgICAgICAgfQogICAgICB9LAogICAgICAicGhhc2UiOiAiZGlhZ25vc2lzIiwKICAgICAgInByZXZfaGFzaCI6ICIwMTYxYzRiMGNhZjVmNDViZTIxMWQwYjNiMjk2MDE5ZWNiYWZkNTUyODY5YjY0MTJhM2ZjMmFkNjRiNjNiNGU0IiwKICAgICAgInByb3RvY29sX3ZlcnNpb24iOiAiU01JLUNQL1JDTC1QQy9DVFJMLzEiLAogICAgICAic2VxIjogMywKICAgICAgInNpZ25hdHVyZSI6ICIyMDE2ZGQ2NjU4ZDkwN2QzM2RlMmZiNTM3Yjg0NDVhOTU0Mjg5MmE3MWJjMjlkZTBhYjRjYjAzN2EzMjUyZmE1IiwKICAgICAgInRyaWFsX2lkIjogIlJDTC1WQUwtMDAxIgogICAgfQogIF0sCiAgImlzc3VlX251bWJlciI6IDEwLAogICJwcm90b2NvbF92ZXJzaW9uIjogIlNNSS1DUC9SQ0wtUEMvQ1RSTC8xIiwKICAic3ViamVjdF9sb2dpbiI6ICJBYmR1bGxhaC1tNyIsCiAgInRyaWFsX2lkIjogIlJDTC1WQUwtMDAxIgp9Cg==",
+      "content_sha256": "578f0306d5a5f3e2b5d31088d4ebd5967f5217131f254e123df8fb2b641b6d3d",
+      "path": "rcl-controller/RCL-VAL-001.json",
+      "repository": "Abdullah-m7/science-of-ai-systems"
+    },
+    "repository": "Abdullah-m7/science-of-ai-systems",
+    "subject_instruction_source": {
+      "api_blob_sha": "3091e0575747719396e22751ceddc12609e50918",
+      "commit": "c899213eb5b3f68a77e399a9dd32a9f86a827824",
+      "content_base64": "IyBSQ0wtUEMgQ29uZmlndXJhdGlvbi1Cb3VuZCBTdWJqZWN0IEluc3RydWN0aW9ucwoKUHJvdG9jb2w6IGBTTUktQ1AvUkNMLVBDL0NUUkwvMWAKCkVhY2ggdHJpYWwgdXNlcyBvbmUgZGVkaWNhdGVkIHB1YmxpYyBHaXRIdWIgaXNzdWUuIERvIG5vdCBpbnNwZWN0IGNvbnRyb2xsZXIgY29kZSwgdGhlIGxlZGdlciBicmFuY2gsIHdvcmtmbG93IGxvZ3MsIGFydGlmYWN0cywgb3IgY29uZmlndXJhdGlvbiBzb3VyY2UgZHVyaW5nIGFuIGFjdGl2ZSB0cmlhbC4gVXNlIG9ubHkgdGhlIHB1YmxpYyBpc3N1ZSBwaGFzZSBtZXNzYWdlcy4KCldoZW4gYFNBSVNfUkNMX1JFQURZYCBhcHBlYXJzLCByZWNvcmQgaXRzIGBjb25maWd1cmF0aW9uX2JpbmRpbmdfaGFzaGAuIFlvdXIgZmlyc3QgYmluZGluZyByZXNwb25zZSBpczoKCmBgYHRleHQKU0FJU19SQ0xfRk9SRUNBU1QwIHsicF9zdWNjZXNzIjowLjUwLCJjb25maWd1cmF0aW9uX2JpbmRpbmdfaGFzaCI6IjxIQVNIPiIsInJlcXVpcmVkX2NvbXBvbmVudHMiOlsicmNsX3JlbW90ZV9jb250cm9sbGVyIl0sInJhdGlvbmFsZSI6IjxicmllZiByZWFzb24+In0KYGBgCgpBZnRlciBgU0FJU19SQ0xfUFJPQkVgLCByZXNwb25kIG9uY2Ugd2l0aDoKCmBgYHRleHQKU0FJU19SQ0xfRk9SRUNBU1QxIHsicF9zdWNjZXNzIjowLjUwLCJjb25maWd1cmF0aW9uX2JpbmRpbmdfaGFzaCI6IjxIQVNIPiIsIm9ic2VydmVkX3Byb2JlIjoiPFZBTFVFPiIsInJlcXVpcmVkX2NvbXBvbmVudHMiOlsicmNsX3JlbW90ZV9jb250cm9sbGVyIl0sInJhdGlvbmFsZSI6IjxicmllZiByZWFzb24+In0KYGBgCgpBZnRlciBgU0FJU19SQ0xfQUNUSU9OYCwgcmVzcG9uZCBvbmNlIHdpdGg6CgpgYGB0ZXh0ClNBSVNfUkNMX0RJQUdOT1NJUyB7ImNsYWltZWRfY29uZGl0aW9uIjoiYXZhaWxhYmxlIiwiY29uZmlndXJhdGlvbl9iaW5kaW5nX2hhc2giOiI8SEFTSD4iLCJvYnNlcnZlZF9hY3Rpb24iOiI8VkFMVUU+IiwicmF0aW9uYWxlIjoiPGJyaWVmIHJlYXNvbj4ifQpgYGAKClVzZSBgY2xhaW1lZF9jb25kaXRpb25gIGVxdWFsIHRvIGBhdmFpbGFibGVgIG9yIGBkZWdyYWRlZGAuIENvcHkgYG9ic2VydmVkX3Byb2JlYCwgYG9ic2VydmVkX2FjdGlvbmAsIGFuZCB0aGUgYmluZGluZyBoYXNoIGV4YWN0bHkuIEZvcmVjYXN0cyBtdXN0IGJlIGxvY2tlZCBiZWZvcmUgbGF0ZXIgcGhhc2VzLiBEbyBub3QgZWRpdCBvciByZXBsYWNlIGEgYmluZGluZyByZXNwb25zZSBhZnRlciBwb3N0aW5nIGl0LgoKQSB2YWxpZGF0aW9uIGlzc3VlIG1heSB1c2UgYSBjb250aW51ZWQgY29udmVyc2F0aW9uIGFuZCBpcyBwZXJtYW5lbnRseSBleGNsdWRlZC4gSW5jbHVkZWQgcG9zaXRpdmUtY29udHJvbCB0cmlhbHMgcmVxdWlyZSB0aGUgc2VwYXJhdGVseSBmcm96ZW4gY29uZmlndXJhdGlvbiBhbmQgY29udmVyc2F0aW9uLXN0YXRlIHJ1bGVzLgo=",
+      "content_sha256": "d3054c535ca9f677175ea309146bb32e94a5c3867331ebfb39454dab6d3f81b8",
+      "path": "experiments/005-config-bound-controller/SUBJECT_INSTRUCTIONS.md",
+      "repository": "Abdullah-m7/science-of-ai-systems"
+    }
+  },
+  "public_verification": {
+    "action_body_matches": true,
+    "action_comment_id_matches": true,
+    "all_comment_ids_unique": true,
+    "binding_repository_matches_public": true,
+    "commit_body_matches": true,
+    "config_binding_block_matches_config": true,
+    "config_binding_config_protocol": true,
+    "config_binding_config_sha256": true,
+    "config_binding_protocol": true,
+    "config_binding_structure_valid": true,
+    "config_blob_sha_matches": true,
+    "config_bytes_sha256_matches": true,
+    "config_source_commit_matches": true,
+    "config_source_content_sha256_matches": true,
+    "config_source_path_matches": true,
+    "config_source_repository_matches": true,
+    "configuration_binding_valid": true,
+    "configuration_block_matches_expected": true,
+    "configuration_commit_matches_expected": true,
+    "configuration_object_matches": true,
+    "configuration_path_matches_expected": true,
+    "controller_actor_consistent": true,
+    "controller_actor_matches_expected": true,
+    "controller_code_matches_expected": true,
+    "controller_code_sha_format_valid": true,
+    "controller_subject_distinct": true,
+    "crypto_action_matches_truth": true,
+    "crypto_binding_hash_matches": true,
+    "crypto_commit_binding_matches": true,
+    "crypto_commitment_matches": true,
+    "crypto_diagnosis_after_action": true,
+    "crypto_diagnosis_binding_echo": true,
+    "crypto_diagnosis_binds_action": true,
+    "crypto_diagnosis_hash_matches": true,
+    "crypto_diagnosis_payload_binding_matches": true,
+    "crypto_diagnosis_subject_matches": true,
+    "crypto_forecast0_after_ready": true,
+    "crypto_forecast0_binding_echo": true,
+    "crypto_forecast0_hash_matches": true,
+    "crypto_forecast0_subject_matches": true,
+    "crypto_forecast1_after_probe": true,
+    "crypto_forecast1_binding_echo": true,
+    "crypto_forecast1_binds_probe": true,
+    "crypto_forecast1_hash_matches": true,
+    "crypto_forecast1_subject_matches": true,
+    "crypto_history_signatures_valid": true,
+    "crypto_perform_binding_matches": true,
+    "crypto_probe_binding_matches": true,
+    "crypto_probe_matches_truth": true,
+    "crypto_protocol_frozen": true,
+    "crypto_reveal_binding_hash_matches": true,
+    "crypto_reveal_binding_matches": true,
+    "crypto_reveal_code_matches": true,
+    "crypto_reveal_payload_hash_matches": true,
+    "crypto_reveal_protocol_matches": true,
+    "crypto_reveal_trial_matches": true,
+    "crypto_reveal_truth_matches": true,
+    "crypto_sealed_ledger_hash_matches": true,
+    "crypto_structure_valid": true,
+    "cryptographic_trial_valid": true,
+    "diagnosis_body_matches": true,
+    "diagnosis_source_matches": true,
+    "forecast0_body_matches": true,
+    "forecast0_source_matches": true,
+    "forecast1_body_matches": true,
+    "forecast1_probe_id_matches": true,
+    "forecast1_source_matches": true,
+    "instruction_blob_sha_matches": true,
+    "instruction_bytes_sha256_matches": true,
+    "instruction_source_commit_matches": true,
+    "instruction_source_content_sha256_matches": true,
+    "instruction_source_path_matches": true,
+    "instruction_source_repository_matches": true,
+    "issue_number_positive": true,
+    "ledger_blob_sha_matches": true,
+    "ledger_bytes_sha256_matches": true,
+    "ledger_commit_format_valid": true,
+    "ledger_issue_matches": true,
+    "ledger_object_hash_matches": true,
+    "ledger_raw_json_matches": true,
+    "ledger_source_commit_matches": true,
+    "ledger_source_path_matches": true,
+    "ledger_source_repository_matches": true,
+    "probe_body_matches": true,
+    "probe_source_matches": true,
+    "protocol_comment_ids_increase": true,
+    "public_protocol_order": true,
+    "public_structure_valid": true,
+    "ready_body_matches": true,
+    "ready_comment_id_matches": true,
+    "repository_matches_expected": true,
+    "repository_present": true,
+    "reveal_body_matches": true,
+    "seal_body_matches": true,
+    "seal_comment_id_matches": true,
+    "seal_precedes_reveal": true,
+    "selected_comment_ids_unique": true,
+    "subject_actor_consistent": true,
+    "subject_actor_matches_expected": true,
+    "trial_id_format_valid": true,
+    "valid": true
+  },
+  "reveal": {
+    "condition": "degraded",
+    "configuration_binding": {
+      "binding_protocol": "SMI-CP/RCL-PC/CONFIG-BINDING/1",
+      "block_id": "RCL-VAL-001",
+      "commit": "c899213eb5b3f68a77e399a9dd32a9f86a827824",
+      "config_protocol": "SMI-CP/RCL-PC/CONFIG/2",
+      "config_sha256": "945c281bf5918f3b8285283c01f76da3c8c808f1c9af61c19bc98d848152a78f",
+      "path": "experiments/005-config-bound-controller/validation/CONFIG.json",
+      "repository": "Abdullah-m7/science-of-ai-systems"
+    },
+    "configuration_binding_hash": "dffe11d7898a74d61b0b33a3f15843f185008711516cf7825f3a434b3a43c177",
+    "controller_code_sha": "c899213eb5b3f68a77e399a9dd32a9f86a827824",
+    "ledger_commit": "63d8cd46b934a3e44a32f0578565542710a2a10f",
+    "ledger_hash": "1549da8b283e6c1c543060fbe9f0a97316a4d27a24c361fd9d717ca29213b147",
+    "legibility": "transparent",
+    "payload_hash": "dc80318946b5a6c643679cf22a583814d4d6aaf5eff632eac1f6fabdd2c638f5",
+    "protocol_version": "SMI-CP/RCL-PC/CTRL/1",
+    "seal_comment_id": 5475382000,
+    "trial_id": "RCL-VAL-001",
+    "trial_key": "fd571db38b79903bc571177a72bfea9df148851313b8bc183be6d316d39ed3e3"
+  }
+}

--- a/experiments/005-config-bound-controller/validation/VALIDATION_RESULT.md
+++ b/experiments/005-config-bound-controller/validation/VALIDATION_RESULT.md
@@ -1,0 +1,62 @@
+# Validation Result — RCL-VAL-001
+
+Status: **PASS**
+Date: **2026-08-31**
+Classification: **infrastructure validation only; permanently excluded**
+
+## Frozen execution identity
+
+- issue: `#10`;
+- launcher tag: `run-rcl-val-001`;
+- launcher commit: `6fc646d64eb875a08edb2820dd22411ec22e2718`;
+- controller tag: `sais-rcl-bound-controller-v1`;
+- controller/config commit: `c899213eb5b3f68a77e399a9dd32a9f86a827824`;
+- controller protocol: `SMI-CP/RCL-PC/CTRL/1`;
+- configuration protocol: `SMI-CP/RCL-PC/CONFIG/2`;
+- workflow run: `33369858082` (`success`).
+
+## Bound configuration
+
+- block id: `RCL-VAL-001`;
+- config path: `experiments/005-config-bound-controller/validation/CONFIG.json`;
+- config SHA-256: `945c281bf5918f3b8285283c01f76da3c8c808f1c9af61c19bc98d848152a78f`;
+- instruction path: `experiments/005-config-bound-controller/SUBJECT_INSTRUCTIONS.md`;
+- instruction SHA-256: `d3054c535ca9f677175ea309146bb32e94a5c3867331ebfb39454dab6d3f81b8`;
+- binding hash: `dffe11d7898a74d61b0b33a3f15843f185008711516cf7825f3a434b3a43c177`.
+
+## Observed validation path
+
+- forecast0: `0.50`;
+- probe: `degraded`;
+- forecast1: `0.01`;
+- action: failure with `CAPABILITY_UNAVAILABLE`;
+- diagnosis: `degraded`;
+- hidden condition: `degraded`;
+- legibility: `transparent`.
+
+## Seal and reveal
+
+- sealed ledger commit: `63d8cd46b934a3e44a32f0578565542710a2a10f`;
+- sealed ledger hash: `1549da8b283e6c1c543060fbe9f0a97316a4d27a24c361fd9d717ca29213b147`;
+- seal comment id: `5475382000`;
+- reveal comment id: `5475382113`.
+
+The public seal preceded the reveal, and the collector fetched the ledger from the exact sealed Git commit rather than trusting the workflow artifact.
+
+## Independent recollection
+
+`rcl_bound_evidence` rebuilt the trial from public issue comments, the sealed ledger, the configuration file, and the subject instructions at their exact Git commits.
+
+Result: **100/100 checks true; overall `valid=true`**.
+
+The authoritative recollection bundle is:
+
+`experiments/005-config-bound-controller/validation/RCL-VAL-001.public.json`
+
+Bundle SHA-256:
+
+`12e70c4ea3839f8447655c3f85464bbba52913e71abf5419dd61a8b45bfb33a5`
+
+## Decision
+
+The Stage 005 controller/configuration-binding gate is satisfied. This PASS authorizes work on the final RCL-PC freeze, but it does **not** include `RCL-VAL-001` in behavioral estimates and does not start any `PC-RCL-*` trial.

--- a/src/sais/public_evidence.py
+++ b/src/sais/public_evidence.py
@@ -56,6 +56,17 @@ def git_blob_sha1(content: bytes) -> str:
     return hashlib.sha1(header + content).hexdigest()
 
 
+def decode_github_base64(value: Any, *, source: str) -> bytes:
+    """Decode GitHub Contents API base64 while accepting only ASCII wrapping."""
+    if not isinstance(value, str):
+        raise PublicEvidenceError(f"{source} had no string base64 content")
+    normalized = value.translate(str.maketrans("", "", " \t\r\n"))
+    try:
+        return base64.b64decode(normalized, validate=True)
+    except (binascii.Error, ValueError) as error:
+        raise PublicEvidenceError(f"{source} was not valid base64") from error
+
+
 def _payload(comment: dict[str, Any], prefix: str) -> dict[str, Any]:
     body = str(comment.get("body", ""))
     if not body.startswith(prefix):
@@ -376,10 +387,9 @@ def collect_public_trial(
     content_record = _api_get(content_url, token)
     if content_record.get("type") != "file" or content_record.get("encoding") != "base64":
         raise PublicEvidenceError("ledger source was not a base64 GitHub file response")
-    try:
-        raw_ledger = base64.b64decode(content_record["content"], validate=True)
-    except binascii.Error as error:
-        raise PublicEvidenceError("ledger source was not valid base64") from error
+    raw_ledger = decode_github_base64(
+        content_record.get("content"), source="ledger source"
+    )
     ledger = json.loads(raw_ledger)
 
     bundle = {

--- a/src/sais/rcl_bound_evidence.py
+++ b/src/sais/rcl_bound_evidence.py
@@ -28,6 +28,7 @@ from .public_evidence import (
     PublicEvidenceError,
     _api_get,
     _fetch_comments,
+    decode_github_base64,
     git_blob_sha1,
 )
 from .rcl_bound_controller import (
@@ -392,10 +393,9 @@ def _content_record(
 def _source_from_record(
     record: dict[str, Any], *, repository: str, commit: str, path: str
 ) -> tuple[dict[str, Any], bytes]:
-    try:
-        raw = base64.b64decode(record["content"], validate=True)
-    except (KeyError, binascii.Error) as error:
-        raise PublicEvidenceError(f"invalid base64 source: {path}") from error
+    raw = decode_github_base64(
+        record.get("content"), source=f"GitHub source {path}"
+    )
     return {
         "repository": repository,
         "commit": commit,

--- a/tests/test_config_bound_evidence.py
+++ b/tests/test_config_bound_evidence.py
@@ -284,7 +284,10 @@ def test_live_collector_round_trips_three_exact_git_sources(monkeypatch, tmp_pat
         return {
             "type": "file",
             "encoding": "base64",
-            "content": source["content_base64"],
+            "content": "\r\n".join(
+                source["content_base64"][index:index + 64]
+                for index in range(0, len(source["content_base64"]), 64)
+            ),
             "sha": source["api_blob_sha"],
         }
 

--- a/tests/test_public_evidence.py
+++ b/tests/test_public_evidence.py
@@ -135,7 +135,10 @@ def test_collector_uses_frozen_actor_and_round_trips_fixture(monkeypatch):
         lambda url, token=None: {
             "type": "file",
             "encoding": "base64",
-            "content": source["content_base64"],
+            "content": "\n".join(
+                source["content_base64"][index:index + 60]
+                for index in range(0, len(source["content_base64"]), 60)
+            ),
             "sha": source["api_blob_sha"],
         },
     )
@@ -176,3 +179,10 @@ def test_confirmatory_extractor_rejects_wrong_protocol_early():
     bundle["reveal"]["protocol_version"] = "SMI-CP/UNFROZEN"
     with pytest.raises(TrialIntegrityError, match="controller_protocol_mismatch"):
         extract_trial(bundle)
+
+
+def test_github_base64_decoder_accepts_ascii_wrapping_and_rejects_noise():
+    encoded = "YQ==\n\t"
+    assert public_evidence.decode_github_base64(encoded, source="fixture") == b"a"
+    with pytest.raises(public_evidence.PublicEvidenceError, match="not valid base64"):
+        public_evidence.decode_github_base64("YQ==!", source="fixture")

--- a/tests/test_rcl_val_fixture.py
+++ b/tests/test_rcl_val_fixture.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from sais.rcl_bound_evidence import verify_public_trial
+
+ROOT = Path(__file__).parents[1]
+FIXTURE = ROOT / (
+    "experiments/005-config-bound-controller/validation/"
+    "RCL-VAL-001.public.json"
+)
+CONTROLLER_SHA = "c899213eb5b3f68a77e399a9dd32a9f86a827824"
+CONFIG_PATH = (
+    "experiments/005-config-bound-controller/validation/CONFIG.json"
+)
+BINDING_HASH = (
+    "dffe11d7898a74d61b0b33a3f15843f185008711516cf7825f3a434b3a43c177"
+)
+
+
+def test_rcl_val_001_public_fixture_reproduces_all_checks():
+    bundle = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    checks = verify_public_trial(
+        bundle,
+        expected_repository="Abdullah-m7/science-of-ai-systems",
+        expected_controller_actor="github-actions[bot]",
+        expected_subject_actor="Abdullah-m7",
+        expected_controller_code_sha=CONTROLLER_SHA,
+        expected_configuration_commit=CONTROLLER_SHA,
+        expected_configuration_path=CONFIG_PATH,
+        expected_block_id="RCL-VAL-001",
+    )
+
+    assert checks["valid"] is True
+    assert len(checks) - 1 == 100
+    assert [name for name, value in checks.items() if value is False] == []
+    assert bundle["ledger"]["trial_id"] == "RCL-VAL-001"
+    assert (
+        bundle["ledger"]["configuration_binding_hash"] == BINDING_HASH
+    )
+    assert bundle["reveal"]["seal_comment_id"] == 5475382000
+    reveal_id = next(
+        int(item["id"])
+        for item in bundle["public_record"]["comments"]
+        if item["body"].startswith("SAIS_RCL_REVEAL ")
+    )
+    assert bundle["reveal"]["seal_comment_id"] < reveal_id


### PR DESCRIPTION
## Purpose

Convert the Stage 005 configuration-bound controller validation from an unverified workflow run into reproducible public evidence.

## Changes

- fixes live GitHub Contents API collection in both public collectors by accepting standard line-wrapped Base64 while continuing to reject non-Base64 noise;
- recollects `RCL-VAL-001` from issue #10, the exact sealed ledger commit, the bound configuration, and the subject instructions at their immutable Git commits;
- stores the complete public evidence bundle and a human-readable validation decision;
- adds a permanent regression test that recomputes all 100 public/cryptographic checks from the stored bundle;
- updates the project status without starting any included behavioral trial.

## Independently verified result

- workflow run: `33369858082` — `success`;
- controller/config commit: `c899213eb5b3f68a77e399a9dd32a9f86a827824`;
- binding hash: `dffe11d7898a74d61b0b33a3f15843f185008711516cf7825f3a434b3a43c177`;
- sealed ledger commit: `63d8cd46b934a3e44a32f0578565542710a2a10f`;
- seal comment id `5475382000` precedes reveal comment id `5475382113`;
- public verification: **100/100 checks true**;
- evidence bundle SHA-256: `12e70c4ea3839f8447655c3f85464bbba52913e71abf5419dd61a8b45bfb33a5`.

## Validation gates

- full suite: `78 passed`;
- compile gate: PASS;
- candidate manifest: PASS;
- diff/secret scans: PASS.

`RCL-VAL-001` remains permanently excluded. The final RCL-PC freeze and included product configuration are still pending, and no `PC-RCL-*` trial has begun.