### PR TITLE
Stage 008C: add fail-closed single-trial dispatch guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ This creates a measurable gap between **believed capability** and **effective ca
 - **Stage 007:** execution-readiness registry and idempotent issue provisioner; all 32 public `PC-RCL-*` surfaces are provisioned (`#18`–`#49`) with zero comments and `included_trials_started = 0`.
 - **Stage 008A:** MOSAIC design/oracle stage; 16 counterfactual quartets (64 pilot-shell trials), Bayesian posterior oracle, label/order distortion metrics, and deterministic excluded P0 simulation. Execution remains HOLD until RCL-PC returns final `PASS`.
 - **Stage 008B:** pre-dispatch RCL-PC subject isolation/sequential-validity addendum and deterministic fresh-chat handoff generator; RCL-PC v2 is explicitly interpreted as repeated randomized measurement of a memory-enabled system.
+- **Stage 008C:** fail-closed single-trial dispatch guard; durable Git reservation must precede workflow dispatch, and run identity is recovered relative to a frozen baseline without blind retry.
 
 Stage 004 deliberately places the original direct transparent/opaque experiment on **HOLD as a headline study**. Because a transparent probe reveals the deterministic action condition, that design is retained as `RCL-PC`, a positive control rather than broad evidence of self-awareness.
 
@@ -105,3 +106,13 @@ sais-mosaic diagnose recency
 ```
 
 `experiments/008-mosaic/EXECUTION_GATE.json` remains `HOLD`; P0 outputs are synthetic and excluded.
+
+Stage 008C can run a **read-only live preflight** without reserving or dispatching anything:
+
+```bash
+sais-rcl-dispatch --repo-root . \
+  --plan experiments/008c-dispatch-guard/DISPATCH_PLAN.json \
+  preflight PC-RCL-001
+```
+
+Apply mode is intentionally not shown as a routine command: it consumes the identifier by pushing a durable reservation before external workflow dispatch and requires exact confirmations for freeze, trial, model, client, memory, and customization state. Use it only when the fresh subject conversation is already prepared.

--- a/experiments/008c-dispatch-guard/DISPATCH_PLAN.json
+++ b/experiments/008c-dispatch-guard/DISPATCH_PLAN.json
@@ -1,0 +1,279 @@
+{
+  "plan_version": "SMI-CP/RCL-PC/DISPATCH-PLAN/1",
+  "prepared_before_first_dispatch": true,
+  "freeze_tag": "sais-rcl-pc-v2",
+  "freeze_commit": "9cae514de94cd7d84ce9cfb293c209a91decb088",
+  "controller_workflow": ".github/workflows/rcl-bound-controller.yml",
+  "controller_tag": "sais-rcl-bound-controller-v1",
+  "controller_commit": "c899213eb5b3f68a77e399a9dd32a9f86a827824",
+  "configuration_commit": "b6a1e728f9ced540306b604dece5e42465b46073",
+  "configuration_path": "experiments/006-rcl-pc-final-freeze/CONFIG.json",
+  "configuration_binding_hash": "6d09daad4c45c1976794add2c7a404aca0e3f27fca1946ad467b900b00d85caa",
+  "subject_login": "Abdullah-m7",
+  "trial_order": [
+    "PC-RCL-001",
+    "PC-RCL-002",
+    "PC-RCL-003",
+    "PC-RCL-004",
+    "PC-RCL-005",
+    "PC-RCL-006",
+    "PC-RCL-007",
+    "PC-RCL-008",
+    "PC-RCL-009",
+    "PC-RCL-010",
+    "PC-RCL-011",
+    "PC-RCL-012",
+    "PC-RCL-013",
+    "PC-RCL-014",
+    "PC-RCL-015",
+    "PC-RCL-016",
+    "PC-RCL-017",
+    "PC-RCL-018",
+    "PC-RCL-019",
+    "PC-RCL-020",
+    "PC-RCL-021",
+    "PC-RCL-022",
+    "PC-RCL-023",
+    "PC-RCL-024",
+    "PC-RCL-025",
+    "PC-RCL-026",
+    "PC-RCL-027",
+    "PC-RCL-028",
+    "PC-RCL-029",
+    "PC-RCL-030",
+    "PC-RCL-031",
+    "PC-RCL-032"
+  ],
+  "max_concurrent_dispatches": 1,
+  "reservation_precedes_dispatch": true,
+  "blind_retry_after_reservation_allowed": false,
+  "dispatch_ledger_branch": "rcl-dispatch-ledger",
+  "registry_snapshot_sha256": "df2d420742674819a2d466e680f98995a629b9d35e40965f731f527d49b7b1c4",
+  "handoff_manifest_sha256": "41d2c78ac35bf13fb64b7245d35acb22473f278d05da3062a8a03396761c8f70",
+  "trials": [
+    {
+      "trial_id": "PC-RCL-001",
+      "issue_number": 18,
+      "issue_url": "https://github.com/Abdullah-m7/science-of-ai-systems/issues/18",
+      "handoff_path": "experiments/008b-subject-isolation/handoffs/PC-RCL-001.md",
+      "handoff_sha256": "e9d6c6bd25ee2b60e97470e862c8fcc0963964f18227da38d3656cb94c54814c"
+    },
+    {
+      "trial_id": "PC-RCL-002",
+      "issue_number": 19,
+      "issue_url": "https://github.com/Abdullah-m7/science-of-ai-systems/issues/19",
+      "handoff_path": "experiments/008b-subject-isolation/handoffs/PC-RCL-002.md",
+      "handoff_sha256": "8e89f88161c9b50f5d4a0c69399535ad883c264b846fb967bcac3068d38e81eb"
+    },
+    {
+      "trial_id": "PC-RCL-003",
+      "issue_number": 20,
+      "issue_url": "https://github.com/Abdullah-m7/science-of-ai-systems/issues/20",
+      "handoff_path": "experiments/008b-subject-isolation/handoffs/PC-RCL-003.md",
+      "handoff_sha256": "caafbc8d2153e7031863672c6703c5b6f30dc95e7c2b9c7d55a66ee056f9a3d6"
+    },
+    {
+      "trial_id": "PC-RCL-004",
+      "issue_number": 21,
+      "issue_url": "https://github.com/Abdullah-m7/science-of-ai-systems/issues/21",
+      "handoff_path": "experiments/008b-subject-isolation/handoffs/PC-RCL-004.md",
+      "handoff_sha256": "95767da4e20000a6f5320a2726f26f93c2d3631d0f1e8518cc6937e6d192108e"
+    },
+    {
+      "trial_id": "PC-RCL-005",
+      "issue_number": 22,
+      "issue_url": "https://github.com/Abdullah-m7/science-of-ai-systems/issues/22",
+      "handoff_path": "experiments/008b-subject-isolation/handoffs/PC-RCL-005.md",
+      "handoff_sha256": "83db49595e28ddce15479001634907d261334ab94c67122a927e011e0e7d5404"
+    },
+    {
+      "trial_id": "PC-RCL-006",
+      "issue_number": 23,
+      "issue_url": "https://github.com/Abdullah-m7/science-of-ai-systems/issues/23",
+      "handoff_path": "experiments/008b-subject-isolation/handoffs/PC-RCL-006.md",
+      "handoff_sha256": "e4cf656f0babb18f371a8c147abe328be76e5fc652a61497c259e8c18934dc94"
+    },
+    {
+      "trial_id": "PC-RCL-007",
+      "issue_number": 24,
+      "issue_url": "https://github.com/Abdullah-m7/science-of-ai-systems/issues/24",
+      "handoff_path": "experiments/008b-subject-isolation/handoffs/PC-RCL-007.md",
+      "handoff_sha256": "b93f92a606ac913f204d01f58bc615bed0e121e53105035db91caa31ca76adab"
+    },
+    {
+      "trial_id": "PC-RCL-008",
+      "issue_number": 25,
+      "issue_url": "https://github.com/Abdullah-m7/science-of-ai-systems/issues/25",
+      "handoff_path": "experiments/008b-subject-isolation/handoffs/PC-RCL-008.md",
+      "handoff_sha256": "5620f9e7fafb43bc72c797283ef59d9fd337f510e41751b4fa070658c07f748a"
+    },
+    {
+      "trial_id": "PC-RCL-009",
+      "issue_number": 26,
+      "issue_url": "https://github.com/Abdullah-m7/science-of-ai-systems/issues/26",
+      "handoff_path": "experiments/008b-subject-isolation/handoffs/PC-RCL-009.md",
+      "handoff_sha256": "13269cf840611484b3a24a72c3e864c37b213a9904fb077bdce33c2d8a486da5"
+    },
+    {
+      "trial_id": "PC-RCL-010",
+      "issue_number": 27,
+      "issue_url": "https://github.com/Abdullah-m7/science-of-ai-systems/issues/27",
+      "handoff_path": "experiments/008b-subject-isolation/handoffs/PC-RCL-010.md",
+      "handoff_sha256": "85c0bd1fb913a1f400c644609c6c99026731c4c94e36b1ffd2cce84e909aa779"
+    },
+    {
+      "trial_id": "PC-RCL-011",
+      "issue_number": 28,
+      "issue_url": "https://github.com/Abdullah-m7/science-of-ai-systems/issues/28",
+      "handoff_path": "experiments/008b-subject-isolation/handoffs/PC-RCL-011.md",
+      "handoff_sha256": "79500a2eda98b254c4eed98e24dcf9062614671aa0f70e82bb24114b877ae659"
+    },
+    {
+      "trial_id": "PC-RCL-012",
+      "issue_number": 29,
+      "issue_url": "https://github.com/Abdullah-m7/science-of-ai-systems/issues/29",
+      "handoff_path": "experiments/008b-subject-isolation/handoffs/PC-RCL-012.md",
+      "handoff_sha256": "477d1bc0592ad4e28bc2f1a742948072abe7aabd152b54a6ba9e110f4903db01"
+    },
+    {
+      "trial_id": "PC-RCL-013",
+      "issue_number": 30,
+      "issue_url": "https://github.com/Abdullah-m7/science-of-ai-systems/issues/30",
+      "handoff_path": "experiments/008b-subject-isolation/handoffs/PC-RCL-013.md",
+      "handoff_sha256": "a0ca278297fad499472a6824e984d51480a3adc73c174c69172df0adfe07c2b5"
+    },
+    {
+      "trial_id": "PC-RCL-014",
+      "issue_number": 31,
+      "issue_url": "https://github.com/Abdullah-m7/science-of-ai-systems/issues/31",
+      "handoff_path": "experiments/008b-subject-isolation/handoffs/PC-RCL-014.md",
+      "handoff_sha256": "a582088dfb9133b0bd692571b1e4765224d97756b559e4979fdf08b2c6b30af7"
+    },
+    {
+      "trial_id": "PC-RCL-015",
+      "issue_number": 32,
+      "issue_url": "https://github.com/Abdullah-m7/science-of-ai-systems/issues/32",
+      "handoff_path": "experiments/008b-subject-isolation/handoffs/PC-RCL-015.md",
+      "handoff_sha256": "59d39b2c007640c07733aa271aa55c236ce67d3f16d9317c3c299cd198a66ceb"
+    },
+    {
+      "trial_id": "PC-RCL-016",
+      "issue_number": 33,
+      "issue_url": "https://github.com/Abdullah-m7/science-of-ai-systems/issues/33",
+      "handoff_path": "experiments/008b-subject-isolation/handoffs/PC-RCL-016.md",
+      "handoff_sha256": "7dacc4c4eefb1e252c37e0fe48db5f7d6498d28ba1c41155f99e22f24d7a21df"
+    },
+    {
+      "trial_id": "PC-RCL-017",
+      "issue_number": 34,
+      "issue_url": "https://github.com/Abdullah-m7/science-of-ai-systems/issues/34",
+      "handoff_path": "experiments/008b-subject-isolation/handoffs/PC-RCL-017.md",
+      "handoff_sha256": "da4fdc7d0bb8098036096ec942f730c73c6242bbcb03459d6578d9048ef9c238"
+    },
+    {
+      "trial_id": "PC-RCL-018",
+      "issue_number": 35,
+      "issue_url": "https://github.com/Abdullah-m7/science-of-ai-systems/issues/35",
+      "handoff_path": "experiments/008b-subject-isolation/handoffs/PC-RCL-018.md",
+      "handoff_sha256": "ea3d8695c3091c2e36007121dbc4cdbfbed4688540a5fb0c855586bdd09aee5c"
+    },
+    {
+      "trial_id": "PC-RCL-019",
+      "issue_number": 36,
+      "issue_url": "https://github.com/Abdullah-m7/science-of-ai-systems/issues/36",
+      "handoff_path": "experiments/008b-subject-isolation/handoffs/PC-RCL-019.md",
+      "handoff_sha256": "837aabb5fb73ba66bb73d80c0678419c9dc0573387df92b924b6715d2fab7c9b"
+    },
+    {
+      "trial_id": "PC-RCL-020",
+      "issue_number": 37,
+      "issue_url": "https://github.com/Abdullah-m7/science-of-ai-systems/issues/37",
+      "handoff_path": "experiments/008b-subject-isolation/handoffs/PC-RCL-020.md",
+      "handoff_sha256": "78cddee9c548197addc02f5a5ab78055c012a36995e82201359741cc721d1c29"
+    },
+    {
+      "trial_id": "PC-RCL-021",
+      "issue_number": 38,
+      "issue_url": "https://github.com/Abdullah-m7/science-of-ai-systems/issues/38",
+      "handoff_path": "experiments/008b-subject-isolation/handoffs/PC-RCL-021.md",
+      "handoff_sha256": "36ae0abb6889d476f448faec429064762bfe880e137a2a765475a76c510de4da"
+    },
+    {
+      "trial_id": "PC-RCL-022",
+      "issue_number": 39,
+      "issue_url": "https://github.com/Abdullah-m7/science-of-ai-systems/issues/39",
+      "handoff_path": "experiments/008b-subject-isolation/handoffs/PC-RCL-022.md",
+      "handoff_sha256": "1ec473538427ec6141dd37909ee5ccb8af51c6209cbeec849251312a33df3749"
+    },
+    {
+      "trial_id": "PC-RCL-023",
+      "issue_number": 40,
+      "issue_url": "https://github.com/Abdullah-m7/science-of-ai-systems/issues/40",
+      "handoff_path": "experiments/008b-subject-isolation/handoffs/PC-RCL-023.md",
+      "handoff_sha256": "befc858f76ca1f3bcdec046fecb36ce164e6b96c2b69bdc45de0cf69da768a82"
+    },
+    {
+      "trial_id": "PC-RCL-024",
+      "issue_number": 41,
+      "issue_url": "https://github.com/Abdullah-m7/science-of-ai-systems/issues/41",
+      "handoff_path": "experiments/008b-subject-isolation/handoffs/PC-RCL-024.md",
+      "handoff_sha256": "086d9e45cf1b0623447864724051ea0bdc947bfb480aca0a6ab31319e60eb657"
+    },
+    {
+      "trial_id": "PC-RCL-025",
+      "issue_number": 42,
+      "issue_url": "https://github.com/Abdullah-m7/science-of-ai-systems/issues/42",
+      "handoff_path": "experiments/008b-subject-isolation/handoffs/PC-RCL-025.md",
+      "handoff_sha256": "507ebe80d70a0403c5572e9e8c51bf689e15a38b38a15443d947384f9198c3c7"
+    },
+    {
+      "trial_id": "PC-RCL-026",
+      "issue_number": 43,
+      "issue_url": "https://github.com/Abdullah-m7/science-of-ai-systems/issues/43",
+      "handoff_path": "experiments/008b-subject-isolation/handoffs/PC-RCL-026.md",
+      "handoff_sha256": "4c11e54f1740b9dacefc1fbd8fc5f0bfe7e0ca1fc5656c949b7eac0377efc5e0"
+    },
+    {
+      "trial_id": "PC-RCL-027",
+      "issue_number": 44,
+      "issue_url": "https://github.com/Abdullah-m7/science-of-ai-systems/issues/44",
+      "handoff_path": "experiments/008b-subject-isolation/handoffs/PC-RCL-027.md",
+      "handoff_sha256": "43e8a390a205a5029f010805de61f54c4b455beeda9da556303b206929b12a48"
+    },
+    {
+      "trial_id": "PC-RCL-028",
+      "issue_number": 45,
+      "issue_url": "https://github.com/Abdullah-m7/science-of-ai-systems/issues/45",
+      "handoff_path": "experiments/008b-subject-isolation/handoffs/PC-RCL-028.md",
+      "handoff_sha256": "5fa65632cf16ba1e21160f0c8e241352c6664ee63004a186a0fed78f3adae38f"
+    },
+    {
+      "trial_id": "PC-RCL-029",
+      "issue_number": 46,
+      "issue_url": "https://github.com/Abdullah-m7/science-of-ai-systems/issues/46",
+      "handoff_path": "experiments/008b-subject-isolation/handoffs/PC-RCL-029.md",
+      "handoff_sha256": "717b5a27d48fa06967d38b9d5214486f40416d345be53978e087db3c3890f27d"
+    },
+    {
+      "trial_id": "PC-RCL-030",
+      "issue_number": 47,
+      "issue_url": "https://github.com/Abdullah-m7/science-of-ai-systems/issues/47",
+      "handoff_path": "experiments/008b-subject-isolation/handoffs/PC-RCL-030.md",
+      "handoff_sha256": "b9b9b89f190230106c0a4b7ca36d012874a7d5c75c728b2ee913b9cd2e42cb4a"
+    },
+    {
+      "trial_id": "PC-RCL-031",
+      "issue_number": 48,
+      "issue_url": "https://github.com/Abdullah-m7/science-of-ai-systems/issues/48",
+      "handoff_path": "experiments/008b-subject-isolation/handoffs/PC-RCL-031.md",
+      "handoff_sha256": "6d22f0829bd624ba75aed1d5f352874985b719f50170cb38bb86835684485d82"
+    },
+    {
+      "trial_id": "PC-RCL-032",
+      "issue_number": 49,
+      "issue_url": "https://github.com/Abdullah-m7/science-of-ai-systems/issues/49",
+      "handoff_path": "experiments/008b-subject-isolation/handoffs/PC-RCL-032.md",
+      "handoff_sha256": "7f386901478e17cbb3babcca82575f9c5e3b7a1bcadeb783d85a83b41b22665b"
+    }
+  ]
+}

--- a/experiments/008c-dispatch-guard/PROTOCOL.md
+++ b/experiments/008c-dispatch-guard/PROTOCOL.md
@@ -1,0 +1,52 @@
+# Stage 008C — Fail-Closed Single-Trial Dispatch Guard
+
+Protocol: `SMI-CP/RCL-PC/DISPATCH/1`
+
+Status: **PRE-DISPATCH IMPLEMENTATION — NO INCLUDED DISPATCH HAS OCCURRED**
+
+## Purpose
+Make the transition from an empty public issue surface to a live RCL-PC trial recoverable under network, process, or client interruption.
+
+The core rule is:
+
+> Durable reservation must precede external workflow dispatch.
+
+A reservation consumes the fixed identifier for retry purposes but creates no hidden capability or legibility assignment. The controller still generates its fresh 256-bit trial key only after Forecast0 is bound.
+
+## Authoritative anchors
+- study freeze: `sais-rcl-pc-v2`
+- controller: `sais-rcl-bound-controller-v1`
+- workflow: `.github/workflows/rcl-bound-controller.yml`
+- live dispatch journal branch: `rcl-dispatch-ledger`
+- fixed order: `PC-RCL-001` through `PC-RCL-032`
+- maximum concurrent dispatches: `1`
+
+## Dispatch sequence
+1. Validate the frozen manifest, registry, handoff manifest, and dispatch plan.
+2. Verify the dedicated issue still has the exact frozen title/body and zero comments.
+3. Verify the exact precommitted handoff bytes for this identifier.
+4. Verify no matching controller workflow run is currently active.
+5. Record the complete baseline set of matching workflow run IDs.
+6. Persist and push a `RESERVED` record to `rcl-dispatch-ledger`.
+7. Only after that push succeeds, submit one GitHub workflow dispatch from the frozen controller tag.
+8. Persist dispatch-command outcome.
+9. Identify the unique new matching workflow run relative to the baseline and persist its run ID/URL.
+10. Never automatically redispatch a reserved identifier.
+## Uncertainty policy
+If the dispatch command fails, times out, or returns an uncertain transport result, the identifier remains reserved. The guard may inspect GitHub for a matching new run, but it may not blindly retry.
+
+If zero matching new runs are discovered after the polling window, record `RUN_UNRESOLVED`. If more than one appears, record `RUN_AMBIGUOUS`. Both states require explicit controller review and consume the identifier unless public evidence proves no trial execution occurred.
+
+## Trial-order policy
+Only the next fixed identifier may be reserved. Before `PC-RCL-NNN`, every earlier identifier must have a terminal dispatch-ledger state (`REVEALED`, `COLLECTED`, or `ABORTED`). No two included trials may be active concurrently.
+
+## Subject boundary
+Reservation and dispatch administration occur outside the subject conversation. Once a run is identified and `SAIS_RCL_READY` is published, the administrator supplies only the already precommitted handoff packet to a newly opened regular ChatGPT conversation.
+
+The current design/controller conversation is not an eligible subject context.
+
+## Product-state confirmation
+Apply mode requires explicit operator confirmations matching the frozen v2 values for model label, client build, memory state, and customization state. A mismatch blocks dispatch before reservation.
+
+## Non-goals
+This guard does not alter the frozen controller, does not generate the hidden trial key, does not answer Forecast0/Forecast1/Diagnosis, and does not compute behavioral results.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ testpaths = ["tests"]
 
 [project.scripts]
 sais-mosaic = "sais.mosaic_cli:main"
+sais-rcl-dispatch = "sais.rcl_dispatch_guard:main"
 sais-rcl-handoff = "sais.rcl_subject_handoff:main"
 sais-rcl-sequential = "sais.rcl_sequential_analysis:main"
 sais-provision-rcl-issues = "sais.rcl_issue_provision:main"

--- a/src/sais/rcl_dispatch_guard.py
+++ b/src/sais/rcl_dispatch_guard.py
@@ -1,0 +1,1158 @@
+"""Fail-closed single-trial dispatcher for the frozen RCL-PC v2 block."""
+
+from __future__ import annotations
+
+import argparse
+from copy import deepcopy
+from datetime import datetime, timezone
+import hashlib
+import json
+from pathlib import Path
+import re
+import secrets
+import shutil
+import subprocess
+import time
+from typing import Any, Callable, Mapping, Sequence
+
+from .rcl_pc_analysis import DEFAULT_MANIFEST, StudySpec, load_study_spec
+from .rcl_registry import issue_title, load_registry, render_issue_body, validate_registry
+
+DISPATCH_PROTOCOL = "SMI-CP/RCL-PC/DISPATCH/1"
+PLAN_VERSION = "SMI-CP/RCL-PC/DISPATCH-PLAN/1"
+RECORD_VERSION = "SMI-CP/RCL-PC/DISPATCH-RECORD/1"
+LEDGER_BRANCH = "rcl-dispatch-ledger"
+DEFAULT_PLAN = (
+    Path(__file__).resolve().parents[2]
+    / "experiments/008c-dispatch-guard/DISPATCH_PLAN.json"
+)
+DEFAULT_REGISTRY = (
+    Path(__file__).resolve().parents[2]
+    / "experiments/007-rcl-pc-execution-readiness/TRIAL_REGISTRY.json"
+)
+DEFAULT_HANDOFF_MANIFEST = (
+    Path(__file__).resolve().parents[2]
+    / "experiments/008b-subject-isolation/HANDOFF_MANIFEST.json"
+)
+HEX40 = re.compile(r"^[0-9a-f]{40}$")
+HEX64 = re.compile(r"^[0-9a-f]{64}$")
+FORBIDDEN_DISPATCH_KEYS = {
+    "condition", "legibility", "key", "trial_key", "assignment", "payload_hash",
+}
+TERMINAL_STATES = {"REVEALED", "COLLECTED", "ABORTED"}
+RECORD_TRANSITIONS = {
+    "RESERVED": {
+        "DISPATCH_SUBMITTED", "DISPATCH_COMMAND_FAILED_UNCERTAIN",
+        "RUN_IDENTIFIED", "RUN_UNRESOLVED", "RUN_AMBIGUOUS", "ABORTED",
+    },
+    "DISPATCH_SUBMITTED": {"RUN_IDENTIFIED", "RUN_UNRESOLVED", "RUN_AMBIGUOUS"},
+    "DISPATCH_COMMAND_FAILED_UNCERTAIN": {"RUN_IDENTIFIED", "RUN_UNRESOLVED", "RUN_AMBIGUOUS"},
+    "RUN_UNRESOLVED": {"RUN_IDENTIFIED", "RUN_AMBIGUOUS", "ABORTED"},
+    "RUN_AMBIGUOUS": {"RUN_IDENTIFIED", "ABORTED"},
+    "RUN_IDENTIFIED": {"READY_OBSERVED", "REVEALED", "ABORTED"},
+    "READY_OBSERVED": {"REVEALED", "ABORTED"},
+    "REVEALED": {"COLLECTED"},
+    "COLLECTED": set(),
+    "ABORTED": set(),
+}
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _run(command: Sequence[str], *, cwd: Path | None = None) -> str:
+    result = subprocess.run(
+        list(command), cwd=cwd, check=True, capture_output=True, text=True
+    )
+    return result.stdout.strip()
+
+
+def _gh(executable: str | None = None) -> str:
+    value = executable or shutil.which("gh")
+    if not value:
+        raise RuntimeError("GitHub CLI `gh` is required")
+    return value
+
+
+def _json_file(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return value
+
+
+def load_dispatch_plan(
+    plan_path: Path,
+    spec: StudySpec,
+    registry_path: Path,
+    handoff_manifest_path: Path,
+) -> dict[str, Any]:
+    plan = _json_file(plan_path)
+    registry = load_registry(registry_path)
+    validate_registry(registry, spec)
+    handoff = _json_file(handoff_manifest_path)
+    checks = {
+        "plan_version": plan.get("plan_version") == PLAN_VERSION,
+        "prepared_before_first_dispatch": plan.get("prepared_before_first_dispatch") is True,
+        "freeze_tag": plan.get("freeze_tag") == spec.freeze_tag,
+        "controller_commit": plan.get("controller_commit") == spec.controller_code_sha,
+        "configuration_commit": plan.get("configuration_commit") == spec.config_commit,
+        "configuration_path": plan.get("configuration_path") == spec.config_path,
+        "configuration_binding_hash": (
+            plan.get("configuration_binding_hash") == spec.expected_binding_hash
+        ),
+        "subject_login": plan.get("subject_login") == spec.subject_login,
+        "trial_order": tuple(plan.get("trial_order", [])) == spec.expected_ids,
+        "max_concurrent": plan.get("max_concurrent_dispatches") == 1,
+        "reservation_first": plan.get("reservation_precedes_dispatch") is True,
+        "no_blind_retry": plan.get("blind_retry_after_reservation_allowed") is False,
+        "ledger_branch": plan.get("dispatch_ledger_branch") == LEDGER_BRANCH,
+        "registry_snapshot": plan.get("registry_snapshot_sha256")
+        == sha256_bytes(registry_path.read_bytes()),
+        "handoff_manifest": plan.get("handoff_manifest_sha256")
+        == sha256_bytes(handoff_manifest_path.read_bytes()),
+    }
+    if not all(checks.values()):
+        failed = [name for name, passed in checks.items() if not passed]
+        raise ValueError("invalid dispatch plan: " + ", ".join(failed))
+
+    registry_by = {row["trial_id"]: row for row in registry["trials"]}
+    handoff_by = {row["trial_id"]: row for row in handoff.get("handoffs", [])}
+    plan_trials = plan.get("trials")
+    if not isinstance(plan_trials, list) or len(plan_trials) != len(spec.expected_ids):
+        raise ValueError("dispatch plan must contain exactly 32 trial records")
+    for row in plan_trials:
+        trial_id = row.get("trial_id") if isinstance(row, dict) else None
+        if trial_id not in registry_by or trial_id not in handoff_by:
+            raise ValueError(f"dispatch plan trial mapping invalid: {trial_id}")
+        registered = registry_by[trial_id]
+        frozen_handoff = handoff_by[trial_id]
+        expected = {
+            "trial_id": trial_id,
+            "issue_number": registered["issue_number"],
+            "issue_url": registered["issue_url"],
+            "handoff_path": frozen_handoff["path"],
+            "handoff_sha256": frozen_handoff["sha256"],
+        }
+        if row != expected:
+            raise ValueError(f"dispatch plan trial record mismatch: {trial_id}")
+    return plan
+
+
+def _plan_trial(plan: Mapping[str, Any], trial_id: str) -> dict[str, Any]:
+    matches = [
+        row for row in plan["trials"]
+        if isinstance(row, dict) and row.get("trial_id") == trial_id
+    ]
+    if len(matches) != 1:
+        raise ValueError(f"trial is not uniquely planned: {trial_id}")
+    return matches[0]
+
+
+def _issue_from_gh(gh: str, repository: str, issue_number: int) -> dict[str, Any]:
+    raw = _run([
+        gh, "issue", "view", str(issue_number), "--repo", repository,
+        "--json", "number,title,url,body,state,comments",
+    ])
+    value = json.loads(raw)
+    if not isinstance(value, dict):
+        raise RuntimeError("GitHub issue view returned non-object")
+    return value
+
+
+def _zero_comments(issue: Mapping[str, Any]) -> bool:
+    comments = issue.get("comments")
+    if comments is None:
+        return True
+    if isinstance(comments, list):
+        return len(comments) == 0
+    if isinstance(comments, int) and not isinstance(comments, bool):
+        return comments == 0
+    return False
+
+
+def verify_issue_surface(
+    issue: Mapping[str, Any],
+    trial: Mapping[str, Any],
+    registry: Mapping[str, Any],
+    spec: StudySpec,
+) -> None:
+    expected_trial = next(
+        row for row in registry["trials"] if row["trial_id"] == trial["trial_id"]
+    )
+    body_trial = deepcopy(expected_trial)
+    body_trial["status"] = "NOT_CREATED"
+    expected_body = render_issue_body(body_trial, registry)
+    checks = {
+        "number": issue.get("number") == trial["issue_number"],
+        "url": issue.get("url") == trial["issue_url"],
+        "title": issue.get("title") == issue_title(str(trial["trial_id"])),
+        "body": str(issue.get("body") or "") == expected_body,
+        "open": str(issue.get("state", "")).upper() == "OPEN",
+        "zero_comments": _zero_comments(issue),
+        "registry_status": expected_trial.get("status") == "ISSUE_CREATED",
+        "repository": str(trial["issue_url"]).startswith(
+            f"https://github.com/{spec.repository}/issues/"
+        ),
+    }
+    if not all(checks.values()):
+        failed = [name for name, passed in checks.items() if not passed]
+        raise RuntimeError("issue preflight failed: " + ", ".join(failed))
+
+
+def _controller_runs(
+    gh: str, repository: str, workflow: str
+) -> list[dict[str, Any]]:
+    raw = _run([
+        gh, "run", "list", "--repo", repository,
+        "--workflow", workflow, "--event", "workflow_dispatch",
+        "--limit", "1000",
+        "--json", (
+            "databaseId,event,headBranch,headSha,createdAt,status,"
+            "conclusion,url,displayTitle"
+        ),
+    ])
+    value = json.loads(raw or "[]")
+    if not isinstance(value, list):
+        raise RuntimeError("GitHub run list returned non-list")
+    return [row for row in value if isinstance(row, dict)]
+
+
+def matching_runs(
+    rows: Sequence[Mapping[str, Any]], plan: Mapping[str, Any]
+) -> list[dict[str, Any]]:
+    return [
+        dict(row)
+        for row in rows
+        if row.get("event") == "workflow_dispatch"
+        and row.get("headBranch") == plan["controller_tag"]
+        and row.get("headSha") == plan["controller_commit"]
+        and isinstance(row.get("databaseId"), int)
+    ]
+
+
+def discover_new_run(
+    baseline_ids: Sequence[int],
+    rows: Sequence[Mapping[str, Any]],
+    plan: Mapping[str, Any],
+) -> dict[str, Any]:
+    baseline = set(int(value) for value in baseline_ids)
+    new_rows = [
+        row for row in matching_runs(rows, plan)
+        if int(row["databaseId"]) not in baseline
+    ]
+    if len(new_rows) == 1:
+        row = new_rows[0]
+        return {"status": "RUN_IDENTIFIED", "run": row, "candidates": [row]}
+    if not new_rows:
+        return {"status": "RUN_UNRESOLVED", "run": None, "candidates": []}
+    return {"status": "RUN_AMBIGUOUS", "run": None, "candidates": new_rows}
+
+
+def _utc_timestamp(value: Any) -> bool:
+    if not isinstance(value, str) or not value.endswith("Z"):
+        return False
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    offset = parsed.utcoffset()
+    return offset is not None and offset.total_seconds() == 0
+
+
+def record_state(record: Mapping[str, Any]) -> str:
+    events = record.get("events")
+    if not isinstance(events, list) or not events:
+        raise ValueError("dispatch record has no events")
+    state = events[-1].get("state")
+    if not isinstance(state, str):
+        raise ValueError("dispatch record has invalid terminal state")
+    return state
+
+
+def validate_dispatch_record(
+    record: Mapping[str, Any], plan: Mapping[str, Any]
+) -> None:
+    trial_id = record.get("trial_id")
+    trial = _plan_trial(plan, str(trial_id))
+    checks = {
+        "record_version": record.get("record_version") == RECORD_VERSION,
+        "protocol": record.get("protocol") == DISPATCH_PROTOCOL,
+        "trial_id": trial_id == trial["trial_id"],
+        "issue_number": record.get("issue_number") == trial["issue_number"],
+        "handoff_sha256": record.get("handoff_sha256") == trial["handoff_sha256"],
+        "freeze_tag": record.get("freeze_tag") == plan["freeze_tag"],
+        "controller_commit": record.get("controller_commit") == plan["controller_commit"],
+        "config_commit": record.get("configuration_commit")
+        == plan["configuration_commit"],
+        "reservation_id": isinstance(record.get("reservation_id"), str)
+        and bool(HEX64.fullmatch(str(record.get("reservation_id")))),
+        "baseline_ids": isinstance(record.get("baseline_run_ids"), list)
+        and all(isinstance(value, int) for value in record.get("baseline_run_ids", [])),
+    }
+    checks["top_level_assignment_free"] = not FORBIDDEN_DISPATCH_KEYS.intersection(record)
+    events = record.get("events")
+    checks["events"] = isinstance(events, list) and bool(events)
+    if isinstance(events, list):
+        checks["event_sequence"] = all(
+            isinstance(event, dict)
+            and event.get("sequence") == index
+            and isinstance(event.get("state"), str)
+            and _utc_timestamp(event.get("at_utc"))
+            for index, event in enumerate(events, start=1)
+        )
+        checks["first_reserved"] = bool(events and events[0].get("state") == "RESERVED")
+        checks["events_assignment_free"] = all(
+            not FORBIDDEN_DISPATCH_KEYS.intersection(event)
+            for event in events if isinstance(event, dict)
+        )
+        transitions_ok = True
+        for previous, current in zip(events, events[1:]):
+            if current.get("state") not in RECORD_TRANSITIONS.get(str(previous.get("state")), set()):
+                transitions_ok = False
+        checks["event_transitions"] = transitions_ok
+        checks["updated_at"] = bool(events and record.get("updated_at_utc") == events[-1].get("at_utc"))
+    else:
+        checks["event_sequence"] = False
+        checks["first_reserved"] = False
+        checks["events_assignment_free"] = False
+        checks["event_transitions"] = False
+        checks["updated_at"] = False
+    if not all(checks.values()):
+        failed = [name for name, passed in checks.items() if not passed]
+        raise ValueError("invalid dispatch record: " + ", ".join(failed))
+
+
+def append_record_event(
+    record: Mapping[str, Any], state: str, *, at_utc: str | None = None, **fields: Any
+) -> dict[str, Any]:
+    if FORBIDDEN_DISPATCH_KEYS.intersection(fields):
+        raise ValueError("hidden assignment material is forbidden in dispatch events")
+    current_state = record_state(record)
+    if state not in RECORD_TRANSITIONS.get(current_state, set()):
+        raise ValueError(f"invalid dispatch state transition: {current_state} -> {state}")
+    updated = deepcopy(dict(record))
+    events = updated.setdefault("events", [])
+    event = {
+        "sequence": len(events) + 1,
+        "at_utc": at_utc or utc_now(),
+        "state": state,
+        **fields,
+    }
+    events.append(event)
+    updated["updated_at_utc"] = event["at_utc"]
+    return updated
+
+
+def make_reservation_record(
+    plan: Mapping[str, Any],
+    trial_id: str,
+    baseline_run_ids: Sequence[int],
+    *,
+    reservation_id: str | None = None,
+    reserved_at_utc: str | None = None,
+) -> dict[str, Any]:
+    trial = _plan_trial(plan, trial_id)
+    nonce = reservation_id or hashlib.sha256(secrets.token_bytes(32)).hexdigest()
+    if not HEX64.fullmatch(nonce):
+        raise ValueError("reservation_id must be a lowercase SHA-256 hex string")
+    at = reserved_at_utc or utc_now()
+    record = {
+        "record_version": RECORD_VERSION,
+        "protocol": DISPATCH_PROTOCOL,
+        "trial_id": trial_id,
+        "issue_number": trial["issue_number"],
+        "issue_url": trial["issue_url"],
+        "handoff_path": trial["handoff_path"],
+        "handoff_sha256": trial["handoff_sha256"],
+        "freeze_tag": plan["freeze_tag"],
+        "freeze_commit": plan["freeze_commit"],
+        "controller_tag": plan["controller_tag"],
+        "controller_commit": plan["controller_commit"],
+        "configuration_commit": plan["configuration_commit"],
+        "configuration_path": plan["configuration_path"],
+        "configuration_binding_hash": plan["configuration_binding_hash"],
+        "reservation_id": nonce,
+        "baseline_run_ids": sorted(set(int(value) for value in baseline_run_ids)),
+        "created_at_utc": at,
+        "updated_at_utc": at,
+        "events": [{"sequence": 1, "at_utc": at, "state": "RESERVED"}],
+    }
+    validate_dispatch_record(record, plan)
+    return record
+
+
+def _remote_branch_exists(repo_root: Path, branch: str) -> bool:
+    remote = _run(["git", "remote", "get-url", "origin"], cwd=repo_root)
+    result = subprocess.run(
+        ["git", "ls-remote", "--heads", remote, f"refs/heads/{branch}"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode not in {0, 2}:
+        raise RuntimeError("could not query dispatch-ledger branch")
+    return bool(result.stdout.strip())
+
+
+def validate_ledger_manifest(
+    value: Mapping[str, Any], plan_path: Path, plan: Mapping[str, Any]
+) -> None:
+    checks = {
+        "ledger_version": value.get("ledger_version") == "SMI-CP/RCL-PC/DISPATCH-LEDGER/1",
+        "dispatch_protocol": value.get("dispatch_protocol") == DISPATCH_PROTOCOL,
+        "plan_sha256": value.get("plan_sha256") == sha256_bytes(plan_path.read_bytes()),
+        "freeze_tag": value.get("freeze_tag") == plan["freeze_tag"],
+        "freeze_commit": value.get("freeze_commit") == plan["freeze_commit"],
+        "controller_tag": value.get("controller_tag") == plan["controller_tag"],
+        "controller_commit": value.get("controller_commit") == plan["controller_commit"],
+        "configuration_commit": value.get("configuration_commit") == plan["configuration_commit"],
+        "configuration_path": value.get("configuration_path") == plan["configuration_path"],
+        "reservation_rule": value.get("rule") == "reservation_commit_must_precede_workflow_dispatch",
+        "created_at": _utc_timestamp(value.get("created_at_utc")),
+    }
+    if not all(checks.values()):
+        failed = [name for name, passed in checks.items() if not passed]
+        raise RuntimeError("dispatch ledger manifest mismatch: " + ", ".join(failed))
+
+
+def _configure_ledger_identity(ledger_dir: Path) -> None:
+    _run(["git", "config", "user.name", "sais-rcl-dispatch-guard"], cwd=ledger_dir)
+    _run([
+        "git", "config", "user.email", "actions@users.noreply.github.com"
+    ], cwd=ledger_dir)
+
+
+def prepare_dispatch_ledger(
+    repo_root: Path,
+    ledger_dir: Path,
+    plan_path: Path,
+    plan: Mapping[str, Any],
+) -> Path:
+    repo_root = repo_root.resolve()
+    ledger_dir = ledger_dir.resolve()
+    branch = str(plan["dispatch_ledger_branch"])
+    origin = _run(["git", "remote", "get-url", "origin"], cwd=repo_root)
+    exists = _remote_branch_exists(repo_root, branch)
+
+    if ledger_dir.exists():
+        if not (ledger_dir / ".git").exists():
+            raise RuntimeError("dispatch ledger directory exists but is not a Git checkout")
+        if _run(["git", "status", "--porcelain"], cwd=ledger_dir):
+            raise RuntimeError("dispatch ledger checkout is dirty")
+        if not exists:
+            raise RuntimeError("local dispatch ledger exists but remote branch does not")
+        _run(["git", "fetch", "origin", branch], cwd=ledger_dir)
+        _run(["git", "reset", "--hard", f"origin/{branch}"], cwd=ledger_dir)
+        _configure_ledger_identity(ledger_dir)
+        validate_ledger_manifest(_json_file(ledger_dir / "rcl-dispatch/MANIFEST.json"), plan_path, plan)
+        return ledger_dir
+
+    if exists:
+        _run([
+            "git", "clone", "--branch", branch, "--single-branch",
+            origin, str(ledger_dir),
+        ], cwd=repo_root)
+        _configure_ledger_identity(ledger_dir)
+        validate_ledger_manifest(_json_file(ledger_dir / "rcl-dispatch/MANIFEST.json"), plan_path, plan)
+        return ledger_dir
+
+    _run(["git", "clone", "--no-checkout", origin, str(ledger_dir)], cwd=repo_root)
+    _run(["git", "switch", "--orphan", branch], cwd=ledger_dir)
+    _configure_ledger_identity(ledger_dir)
+    manifest = {
+        "ledger_version": "SMI-CP/RCL-PC/DISPATCH-LEDGER/1",
+        "created_at_utc": utc_now(),
+        "dispatch_protocol": DISPATCH_PROTOCOL,
+        "plan_sha256": sha256_bytes(plan_path.read_bytes()),
+        "freeze_tag": plan["freeze_tag"],
+        "freeze_commit": plan["freeze_commit"],
+        "controller_tag": plan["controller_tag"],
+        "controller_commit": plan["controller_commit"],
+        "configuration_commit": plan["configuration_commit"],
+        "configuration_path": plan["configuration_path"],
+        "rule": "reservation_commit_must_precede_workflow_dispatch",
+    }
+    target = ledger_dir / "rcl-dispatch" / "MANIFEST.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    _run(["git", "add", "rcl-dispatch/MANIFEST.json"], cwd=ledger_dir)
+    _run(["git", "commit", "-m", "rcl-dispatch: initialize ledger"], cwd=ledger_dir)
+    _run(["git", "push", "origin", f"HEAD:refs/heads/{branch}"], cwd=ledger_dir)
+    validate_ledger_manifest(manifest, plan_path, plan)
+    return ledger_dir
+
+
+def load_dispatch_records(
+    ledger_dir: Path, plan: Mapping[str, Any]
+) -> dict[str, dict[str, Any]]:
+    root = ledger_dir / "rcl-dispatch"
+    records: dict[str, dict[str, Any]] = {}
+    if not root.exists():
+        return records
+    for path in sorted(root.glob("PC-RCL-*.json")):
+        value = _json_file(path)
+        validate_dispatch_record(value, plan)
+        trial_id = str(value["trial_id"])
+        if trial_id in records:
+            raise ValueError(f"duplicate dispatch record: {trial_id}")
+        records[trial_id] = value
+    return records
+
+
+def assert_dispatch_order(
+    plan: Mapping[str, Any],
+    trial_id: str,
+    records: Mapping[str, Mapping[str, Any]],
+) -> None:
+    order = list(plan["trial_order"])
+    if trial_id not in order:
+        raise ValueError(f"trial is not in fixed dispatch order: {trial_id}")
+    if trial_id in records:
+        raise RuntimeError(f"trial is already reserved and may not be retried: {trial_id}")
+    active = [
+        key for key, record in records.items()
+        if record_state(record) not in TERMINAL_STATES
+    ]
+    if active:
+        raise RuntimeError("nonterminal prior dispatch record exists: " + ", ".join(sorted(active)))
+    index = order.index(trial_id)
+    missing_prior = [
+        key for key in order[:index]
+        if key not in records or record_state(records[key]) not in TERMINAL_STATES
+    ]
+    if missing_prior:
+        raise RuntimeError(
+            "fixed-order predecessor is not terminal: " + ", ".join(missing_prior)
+        )
+
+
+def persist_dispatch_record(
+    ledger_dir: Path,
+    record: Mapping[str, Any],
+    plan: Mapping[str, Any],
+    *,
+    action: str,
+) -> str:
+    validate_dispatch_record(record, plan)
+    if _run(["git", "status", "--porcelain"], cwd=ledger_dir):
+        raise RuntimeError("dispatch ledger checkout is dirty before persistence")
+    trial_id = str(record["trial_id"])
+    target = ledger_dir / "rcl-dispatch" / f"{trial_id}.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(record, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _run(["git", "add", str(target.relative_to(ledger_dir))], cwd=ledger_dir)
+    _run(["git", "commit", "-m", f"rcl-dispatch: {action} {trial_id}"], cwd=ledger_dir)
+    branch = str(plan["dispatch_ledger_branch"])
+    _run(["git", "push", "origin", f"HEAD:refs/heads/{branch}"], cwd=ledger_dir)
+    return _run(["git", "rev-parse", "HEAD"], cwd=ledger_dir)
+
+
+def load_remote_dispatch_records(
+    repo_root: Path, plan: Mapping[str, Any], plan_path: Path = DEFAULT_PLAN
+) -> dict[str, dict[str, Any]]:
+    branch = str(plan["dispatch_ledger_branch"])
+    if not _remote_branch_exists(repo_root, branch):
+        return {}
+    _run([
+        "git", "fetch", "origin",
+        f"refs/heads/{branch}:refs/remotes/origin/{branch}",
+    ], cwd=repo_root)
+    manifest_raw = _run([
+        "git", "show", f"origin/{branch}:rcl-dispatch/MANIFEST.json"
+    ], cwd=repo_root)
+    manifest = json.loads(manifest_raw)
+    if not isinstance(manifest, dict):
+        raise RuntimeError("remote dispatch ledger manifest is not an object")
+    validate_ledger_manifest(manifest, plan_path, plan)
+    tree = _run([
+        "git", "ls-tree", "-r", "--name-only", f"origin/{branch}",
+        "--", "rcl-dispatch",
+    ], cwd=repo_root)
+    records: dict[str, dict[str, Any]] = {}
+    for relative in tree.splitlines():
+        if not re.fullmatch(r"rcl-dispatch/PC-RCL-[0-9]{3}\.json", relative):
+            continue
+        raw = _run(["git", "show", f"origin/{branch}:{relative}"], cwd=repo_root)
+        value = json.loads(raw)
+        if not isinstance(value, dict):
+            raise ValueError(f"remote dispatch record is not an object: {relative}")
+        validate_dispatch_record(value, plan)
+        records[str(value["trial_id"])] = value
+    return records
+
+
+def verify_git_anchors(repo_root: Path, plan: Mapping[str, Any]) -> None:
+    freeze = _run(["git", "rev-list", "-n", "1", plan["freeze_tag"]], cwd=repo_root)
+    controller = _run(
+        ["git", "rev-list", "-n", "1", plan["controller_tag"]], cwd=repo_root
+    )
+    if freeze != plan["freeze_commit"]:
+        raise RuntimeError("freeze tag target does not match dispatch plan")
+    if controller != plan["controller_commit"]:
+        raise RuntimeError("controller tag target does not match dispatch plan")
+    result = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", plan["configuration_commit"], freeze],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError("configuration commit is not an ancestor of freeze commit")
+
+
+def _verify_handoff(root: Path, trial: Mapping[str, Any]) -> None:
+    path = root / str(trial["handoff_path"])
+    if not path.is_file():
+        raise RuntimeError("precommitted subject handoff is missing")
+    actual = sha256_bytes(path.read_bytes())
+    if actual != trial["handoff_sha256"]:
+        raise RuntimeError("precommitted subject handoff bytes do not match plan")
+
+
+def preflight(
+    *,
+    trial_id: str,
+    repo_root: Path,
+    plan_path: Path = DEFAULT_PLAN,
+    manifest_path: Path = DEFAULT_MANIFEST,
+    registry_path: Path = DEFAULT_REGISTRY,
+    handoff_manifest_path: Path = DEFAULT_HANDOFF_MANIFEST,
+    gh_executable: str | None = None,
+) -> dict[str, Any]:
+    repo_root = repo_root.resolve()
+    spec = load_study_spec(manifest_path, root=repo_root)
+    registry = load_registry(registry_path)
+    validate_registry(registry, spec)
+    plan = load_dispatch_plan(plan_path, spec, registry_path, handoff_manifest_path)
+    trial = _plan_trial(plan, trial_id)
+    verify_git_anchors(repo_root, plan)
+    _verify_handoff(repo_root, trial)
+    records = load_remote_dispatch_records(repo_root, plan, plan_path)
+    assert_dispatch_order(plan, trial_id, records)
+
+    gh = _gh(gh_executable)
+    issue = _issue_from_gh(gh, spec.repository, int(trial["issue_number"]))
+    verify_issue_surface(issue, trial, registry, spec)
+    all_runs = _controller_runs(gh, spec.repository, str(plan["controller_workflow"]))
+    matched = matching_runs(all_runs, plan)
+    active = [row for row in matched if row.get("status") != "completed"]
+    if active:
+        raise RuntimeError("a matching frozen controller workflow run is already active")
+    baseline_ids = sorted(int(row["databaseId"]) for row in matched)
+    return {
+        "ready": True,
+        "trial_id": trial_id,
+        "issue_number": trial["issue_number"],
+        "issue_url": trial["issue_url"],
+        "handoff_path": trial["handoff_path"],
+        "handoff_sha256": trial["handoff_sha256"],
+        "baseline_run_ids": baseline_ids,
+        "prior_dispatch_records": sorted(records),
+        "included_registry_started": registry["included_trials_started"],
+    }
+
+
+def verify_operator_confirmations(
+    config: Mapping[str, Any],
+    *,
+    freeze: str | None,
+    trial: str | None,
+    trial_id: str,
+    model: str | None,
+    client: str | None,
+    memory: str | None,
+    customization: str | None,
+    spec: StudySpec,
+) -> None:
+    expected = {
+        "freeze": spec.freeze_tag,
+        "trial": trial_id,
+        "model": config.get("model_label"),
+        "client": config.get("interface_build"),
+        "memory": config.get("memory_state"),
+        "customization": config.get("customization_state"),
+    }
+    actual = {
+        "freeze": freeze,
+        "trial": trial,
+        "model": model,
+        "client": client,
+        "memory": memory,
+        "customization": customization,
+    }
+    failed = [name for name in expected if actual[name] != expected[name]]
+    if failed:
+        raise RuntimeError(
+            "operator product-state confirmation mismatch: " + ", ".join(failed)
+        )
+
+
+def _dispatch_command(
+    gh: str,
+    spec: StudySpec,
+    plan: Mapping[str, Any],
+    trial: Mapping[str, Any],
+) -> subprocess.CompletedProcess[str]:
+    command = [
+        gh, "workflow", "run", str(plan["controller_workflow"]),
+        "--repo", spec.repository,
+        "--ref", str(plan["controller_tag"]),
+        "-f", f"trial_id={trial['trial_id']}",
+        "-f", f"issue_number={trial['issue_number']}",
+        "-f", f"subject_login={spec.subject_login}",
+        "-f", f"config_commit={plan['configuration_commit']}",
+        "-f", f"config_path={plan['configuration_path']}",
+    ]
+    return subprocess.run(command, capture_output=True, text=True)
+
+
+def _poll_for_new_run(
+    gh: str,
+    spec: StudySpec,
+    plan: Mapping[str, Any],
+    baseline_ids: Sequence[int],
+    *,
+    poll_seconds: int,
+    sleep: Callable[[float], None] = time.sleep,
+) -> dict[str, Any]:
+    deadline = time.monotonic() + max(0, poll_seconds)
+    last = {"status": "RUN_UNRESOLVED", "run": None, "candidates": []}
+    while True:
+        rows = _controller_runs(gh, spec.repository, str(plan["controller_workflow"]))
+        last = discover_new_run(baseline_ids, rows, plan)
+        if last["status"] != "RUN_UNRESOLVED":
+            return last
+        if time.monotonic() >= deadline:
+            return last
+        sleep(min(2.0, max(0.0, deadline - time.monotonic())))
+
+
+def dispatch_once(
+    *,
+    trial_id: str,
+    repo_root: Path,
+    ledger_dir: Path,
+    plan_path: Path = DEFAULT_PLAN,
+    manifest_path: Path = DEFAULT_MANIFEST,
+    registry_path: Path = DEFAULT_REGISTRY,
+    handoff_manifest_path: Path = DEFAULT_HANDOFF_MANIFEST,
+    gh_executable: str | None = None,
+    apply: bool = False,
+    confirm_freeze: str | None = None,
+    confirm_trial: str | None = None,
+    confirm_model: str | None = None,
+    confirm_client: str | None = None,
+    confirm_memory: str | None = None,
+    confirm_customization: str | None = None,
+    poll_seconds: int = 90,
+) -> dict[str, Any]:
+    repo_root = repo_root.resolve()
+    pre = preflight(
+        trial_id=trial_id,
+        repo_root=repo_root,
+        plan_path=plan_path,
+        manifest_path=manifest_path,
+        registry_path=registry_path,
+        handoff_manifest_path=handoff_manifest_path,
+        gh_executable=gh_executable,
+    )
+    if not apply:
+        return {"mode": "DRY_RUN", **pre}
+
+    spec = load_study_spec(manifest_path, root=repo_root)
+    registry = load_registry(registry_path)
+    validate_registry(registry, spec)
+    plan = load_dispatch_plan(plan_path, spec, registry_path, handoff_manifest_path)
+    trial = _plan_trial(plan, trial_id)
+    config = _json_file(repo_root / spec.config_path)
+    verify_operator_confirmations(
+        config,
+        freeze=confirm_freeze,
+        trial=confirm_trial,
+        trial_id=trial_id,
+        model=confirm_model,
+        client=confirm_client,
+        memory=confirm_memory,
+        customization=confirm_customization,
+        spec=spec,
+    )
+    gh = _gh(gh_executable)
+
+    ledger = prepare_dispatch_ledger(repo_root, ledger_dir, plan_path, plan)
+    records = load_dispatch_records(ledger, plan)
+    assert_dispatch_order(plan, trial_id, records)
+    issue = _issue_from_gh(gh, spec.repository, int(trial["issue_number"]))
+    verify_issue_surface(issue, trial, registry, spec)
+    run_rows = _controller_runs(gh, spec.repository, str(plan["controller_workflow"]))
+    matched = matching_runs(run_rows, plan)
+    if any(row.get("status") != "completed" for row in matched):
+        raise RuntimeError("matching frozen controller run became active before reservation")
+    baseline_ids = sorted(int(row["databaseId"]) for row in matched)
+
+    reservation = make_reservation_record(plan, trial_id, baseline_ids)
+    reserve_commit = persist_dispatch_record(
+        ledger, reservation, plan, action="reserve"
+    )
+
+    # Re-check the mutable public/runtime surfaces after the durable reservation.
+    # Nothing external is dispatched if either changed during the reservation push.
+    post_issue = _issue_from_gh(gh, spec.repository, int(trial["issue_number"]))
+    try:
+        verify_issue_surface(post_issue, trial, registry, spec)
+    except RuntimeError as error:
+        record = append_record_event(
+            reservation,
+            "ABORTED",
+            reason="issue_changed_after_reservation_before_dispatch",
+            detail_sha256=sha256_bytes(str(error).encode("utf-8")),
+        )
+        abort_commit = persist_dispatch_record(
+            ledger, record, plan, action="abort-before-dispatch"
+        )
+        return {
+            "mode": "APPLY_ABORTED_PRE_DISPATCH",
+            "trial_id": trial_id,
+            "reservation_commit": reserve_commit,
+            "dispatch_record_commit": abort_commit,
+            "reason": "issue_changed_after_reservation_before_dispatch",
+            "external_dispatch_performed": False,
+            "automatic_retry_allowed": False,
+        }
+
+    post_rows = _controller_runs(gh, spec.repository, str(plan["controller_workflow"]))
+    external = discover_new_run(baseline_ids, post_rows, plan)
+    if external["status"] != "RUN_UNRESOLVED":
+        record = append_record_event(
+            reservation,
+            "RUN_AMBIGUOUS",
+            candidate_run_ids=[row["databaseId"] for row in external["candidates"]],
+            reason="matching_run_appeared_after_reservation_before_local_dispatch",
+        )
+        ambiguity_commit = persist_dispatch_record(
+            ledger, record, plan, action="record-pre-dispatch-run-race"
+        )
+        return {
+            "mode": "APPLY_BLOCKED_PRE_DISPATCH",
+            "trial_id": trial_id,
+            "reservation_commit": reserve_commit,
+            "dispatch_record_commit": ambiguity_commit,
+            "run_discovery": external,
+            "external_dispatch_performed": False,
+            "automatic_retry_allowed": False,
+        }
+
+    command_result = _dispatch_command(gh, spec, plan, trial)
+    command_state = (
+        "DISPATCH_SUBMITTED"
+        if command_result.returncode == 0
+        else "DISPATCH_COMMAND_FAILED_UNCERTAIN"
+    )
+    stdout_bytes = (command_result.stdout or "").encode("utf-8")
+    stderr_bytes = (command_result.stderr or "").encode("utf-8")
+    record = append_record_event(
+        reservation,
+        command_state,
+        returncode=command_result.returncode,
+        stdout_sha256=sha256_bytes(stdout_bytes),
+        stdout_bytes=len(stdout_bytes),
+        stderr_sha256=sha256_bytes(stderr_bytes),
+        stderr_bytes=len(stderr_bytes),
+    )
+    command_commit = persist_dispatch_record(
+        ledger, record, plan, action="submit"
+    )
+
+    discovery = _poll_for_new_run(
+        gh, spec, plan, baseline_ids, poll_seconds=poll_seconds
+    )
+    if discovery["status"] == "RUN_IDENTIFIED":
+        run = discovery["run"]
+        record = append_record_event(
+            record,
+            "RUN_IDENTIFIED",
+            run_id=run["databaseId"],
+            run_url=run.get("url"),
+            run_created_at=run.get("createdAt"),
+            run_status=run.get("status"),
+        )
+        final_action = "identify-run"
+    else:
+        record = append_record_event(
+            record,
+            discovery["status"],
+            candidate_run_ids=[row["databaseId"] for row in discovery["candidates"]],
+        )
+        final_action = "record-unresolved-run"
+    final_commit = persist_dispatch_record(
+        ledger, record, plan, action=final_action
+    )
+    return {
+        "mode": "APPLY",
+        "trial_id": trial_id,
+        "issue_url": trial["issue_url"],
+        "handoff_path": trial["handoff_path"],
+        "handoff_sha256": trial["handoff_sha256"],
+        "reservation_commit": reserve_commit,
+        "dispatch_command_commit": command_commit,
+        "dispatch_record_commit": final_commit,
+        "dispatch_command_returncode": command_result.returncode,
+        "run_discovery": discovery,
+        "automatic_retry_allowed": False,
+    }
+
+
+def _record_run_id(record: Mapping[str, Any]) -> int | None:
+    for event in reversed(record.get("events", [])):
+        if event.get("state") == "RUN_IDENTIFIED" and isinstance(event.get("run_id"), int):
+            return int(event["run_id"])
+    return None
+
+
+def recover_run(
+    *,
+    trial_id: str,
+    repo_root: Path,
+    ledger_dir: Path,
+    plan_path: Path = DEFAULT_PLAN,
+    manifest_path: Path = DEFAULT_MANIFEST,
+    registry_path: Path = DEFAULT_REGISTRY,
+    handoff_manifest_path: Path = DEFAULT_HANDOFF_MANIFEST,
+    gh_executable: str | None = None,
+) -> dict[str, Any]:
+    spec = load_study_spec(manifest_path, root=repo_root)
+    plan = load_dispatch_plan(plan_path, spec, registry_path, handoff_manifest_path)
+    gh = _gh(gh_executable)
+    ledger = prepare_dispatch_ledger(repo_root, ledger_dir, plan_path, plan)
+    records = load_dispatch_records(ledger, plan)
+    if trial_id not in records:
+        raise RuntimeError("no durable reservation exists for this trial")
+    record = records[trial_id]
+    state = record_state(record)
+    if state in {"RUN_IDENTIFIED", "READY_OBSERVED", "REVEALED", "COLLECTED", "ABORTED"}:
+        return {"trial_id": trial_id, "state": state, "run_id": _record_run_id(record)}
+    rows = _controller_runs(gh, spec.repository, str(plan["controller_workflow"]))
+    discovery = discover_new_run(record["baseline_run_ids"], rows, plan)
+    new_state = discovery["status"]
+    if state == new_state:
+        return {"trial_id": trial_id, "state": state, "run_discovery": discovery}
+    if new_state == "RUN_IDENTIFIED":
+        run = discovery["run"]
+        updated = append_record_event(
+            record,
+            "RUN_IDENTIFIED",
+            run_id=run["databaseId"],
+            run_url=run.get("url"),
+            run_created_at=run.get("createdAt"),
+            run_status=run.get("status"),
+            recovery=True,
+        )
+        action = "recover-run"
+    else:
+        updated = append_record_event(
+            record,
+            new_state,
+            candidate_run_ids=[row["databaseId"] for row in discovery["candidates"]],
+            recovery=True,
+        )
+        action = "record-recovery-state"
+    commit = persist_dispatch_record(ledger, updated, plan, action=action)
+    return {
+        "trial_id": trial_id,
+        "state": record_state(updated),
+        "dispatch_record_commit": commit,
+        "run_discovery": discovery,
+    }
+
+
+def _issue_phase_presence(issue: Mapping[str, Any]) -> dict[str, bool]:
+    comments = issue.get("comments")
+    if not isinstance(comments, list):
+        comments = []
+    bodies = [str(row.get("body") or "") for row in comments if isinstance(row, dict)]
+    return {
+        "ready": any(body.startswith("SAIS_RCL_READY ") for body in bodies),
+        "forecast0": any(body.startswith("SAIS_RCL_FORECAST0 ") for body in bodies),
+        "probe": any(body.startswith("SAIS_RCL_PROBE ") for body in bodies),
+        "forecast1": any(body.startswith("SAIS_RCL_FORECAST1 ") for body in bodies),
+        "action": any(body.startswith("SAIS_RCL_ACTION ") for body in bodies),
+        "diagnosis": any(body.startswith("SAIS_RCL_DIAGNOSIS ") for body in bodies),
+        "reveal": any(body.startswith("SAIS_RCL_REVEAL ") for body in bodies),
+    }
+
+
+def _run_view(gh: str, repository: str, run_id: int) -> dict[str, Any]:
+    raw = _run([
+        gh, "run", "view", str(run_id), "--repo", repository,
+        "--json", (
+            "databaseId,workflowName,event,headBranch,headSha,createdAt,"
+            "startedAt,status,conclusion,url,displayTitle"
+        ),
+    ])
+    value = json.loads(raw)
+    if not isinstance(value, dict):
+        raise RuntimeError("GitHub run view returned non-object")
+    return value
+
+
+def reconcile_trial(
+    *,
+    trial_id: str,
+    repo_root: Path,
+    ledger_dir: Path,
+    plan_path: Path = DEFAULT_PLAN,
+    manifest_path: Path = DEFAULT_MANIFEST,
+    registry_path: Path = DEFAULT_REGISTRY,
+    handoff_manifest_path: Path = DEFAULT_HANDOFF_MANIFEST,
+    gh_executable: str | None = None,
+) -> dict[str, Any]:
+    spec = load_study_spec(manifest_path, root=repo_root)
+    registry = load_registry(registry_path)
+    validate_registry(registry, spec)
+    plan = load_dispatch_plan(plan_path, spec, registry_path, handoff_manifest_path)
+    trial = _plan_trial(plan, trial_id)
+    gh = _gh(gh_executable)
+    ledger = prepare_dispatch_ledger(repo_root, ledger_dir, plan_path, plan)
+    records = load_dispatch_records(ledger, plan)
+    if trial_id not in records:
+        raise RuntimeError("trial has no durable dispatch reservation")
+    record = records[trial_id]
+    state = record_state(record)
+    if state in TERMINAL_STATES:
+        return {"trial_id": trial_id, "state": state, "run_id": _record_run_id(record)}
+    run_id = _record_run_id(record)
+    if run_id is None:
+        raise RuntimeError("run identity is unresolved; use recover-run first")
+    run = _run_view(gh, spec.repository, run_id)
+    if (
+        run.get("event") != "workflow_dispatch"
+        or run.get("headBranch") != plan["controller_tag"]
+        or run.get("headSha") != plan["controller_commit"]
+    ):
+        raise RuntimeError("recorded run no longer matches the frozen controller identity")
+    issue = _issue_from_gh(gh, spec.repository, int(trial["issue_number"]))
+    phases = _issue_phase_presence(issue)
+    updated = record
+    actions: list[str] = []
+    if phases["reveal"] and state in {"RUN_IDENTIFIED", "READY_OBSERVED"}:
+        updated = append_record_event(
+            updated, "REVEALED", run_id=run_id, run_url=run.get("url")
+        )
+        actions.append("reveal")
+    elif phases["ready"] and state == "RUN_IDENTIFIED":
+        updated = append_record_event(
+            updated, "READY_OBSERVED", run_id=run_id, run_url=run.get("url")
+        )
+        actions.append("ready")
+    state_after = record_state(updated)
+    if (
+        state_after not in TERMINAL_STATES
+        and run.get("status") == "completed"
+        and run.get("conclusion") != "success"
+        and not phases["reveal"]
+    ):
+        updated = append_record_event(
+            updated,
+            "ABORTED",
+            run_id=run_id,
+            run_url=run.get("url"),
+            run_conclusion=run.get("conclusion"),
+            reason="controller_run_completed_without_reveal",
+        )
+        actions.append("abort")
+    commit = None
+    if updated != record:
+        commit = persist_dispatch_record(
+            ledger, updated, plan, action="reconcile-" + "-".join(actions)
+        )
+    return {
+        "trial_id": trial_id,
+        "state": record_state(updated),
+        "run": run,
+        "issue_phases": phases,
+        "dispatch_record_commit": commit,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Fail-closed dispatcher for one frozen RCL-PC trial"
+    )
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--registry", type=Path, default=DEFAULT_REGISTRY)
+    parser.add_argument("--handoff-manifest", type=Path, default=DEFAULT_HANDOFF_MANIFEST)
+    parser.add_argument("--plan", type=Path, default=DEFAULT_PLAN)
+    parser.add_argument("--ledger-dir", type=Path, default=Path("/tmp/sais-rcl-dispatch-ledger"))
+    parser.add_argument("--gh-executable")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    pre = sub.add_parser("preflight")
+    pre.add_argument("trial_id")
+
+    dispatch = sub.add_parser("dispatch")
+    dispatch.add_argument("trial_id")
+    dispatch.add_argument("--apply", action="store_true")
+    dispatch.add_argument("--confirm-freeze")
+    dispatch.add_argument("--confirm-trial")
+    dispatch.add_argument("--confirm-model")
+    dispatch.add_argument("--confirm-client")
+    dispatch.add_argument("--confirm-memory")
+    dispatch.add_argument("--confirm-customization")
+    dispatch.add_argument("--poll-seconds", type=int, default=90)
+
+    recover = sub.add_parser("recover-run")
+    recover.add_argument("trial_id")
+
+    reconcile = sub.add_parser("reconcile")
+    reconcile.add_argument("trial_id")
+
+    args = parser.parse_args()
+    common = {
+        "repo_root": args.repo_root,
+        "manifest_path": args.manifest,
+        "registry_path": args.registry,
+        "handoff_manifest_path": args.handoff_manifest,
+        "gh_executable": args.gh_executable,
+    }
+    if args.command == "preflight":
+        report = preflight(trial_id=args.trial_id, plan_path=args.plan, **common)
+    elif args.command == "dispatch":
+        report = dispatch_once(
+            trial_id=args.trial_id,
+            ledger_dir=args.ledger_dir,
+            plan_path=args.plan,
+            apply=args.apply,
+            confirm_freeze=args.confirm_freeze,
+            confirm_trial=args.confirm_trial,
+            confirm_model=args.confirm_model,
+            confirm_client=args.confirm_client,
+            confirm_memory=args.confirm_memory,
+            confirm_customization=args.confirm_customization,
+            poll_seconds=args.poll_seconds,
+            **common,
+        )
+    elif args.command == "recover-run":
+        report = recover_run(
+            trial_id=args.trial_id,
+            ledger_dir=args.ledger_dir,
+            plan_path=args.plan,
+            **common,
+        )
+    else:
+        report = reconcile_trial(
+            trial_id=args.trial_id,
+            ledger_dir=args.ledger_dir,
+            plan_path=args.plan,
+            **common,
+        )
+    print(json.dumps(report, indent=2, sort_keys=True, allow_nan=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_rcl_dispatch_guard.py
+++ b/tests/test_rcl_dispatch_guard.py
@@ -1,0 +1,556 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+
+import pytest
+
+import sais.rcl_dispatch_guard as guard
+from sais.rcl_dispatch_guard import (
+    append_record_event,
+    assert_dispatch_order,
+    discover_new_run,
+    load_dispatch_plan,
+    make_reservation_record,
+    record_state,
+    validate_dispatch_record,
+    verify_issue_surface,
+    verify_operator_confirmations,
+)
+from sais.rcl_pc_analysis import load_study_spec
+from sais.rcl_registry import issue_title, load_registry, render_issue_body
+
+ROOT = Path(__file__).parents[1]
+MANIFEST = ROOT / "experiments/006-rcl-pc-final-freeze/FREEZE_MANIFEST.json"
+REGISTRY = ROOT / "experiments/007-rcl-pc-execution-readiness/TRIAL_REGISTRY.json"
+HANDOFFS = ROOT / "experiments/008b-subject-isolation/HANDOFF_MANIFEST.json"
+PLAN = ROOT / "experiments/008c-dispatch-guard/DISPATCH_PLAN.json"
+
+
+def _inputs():
+    spec = load_study_spec(MANIFEST, root=ROOT)
+    registry = load_registry(REGISTRY)
+    plan = load_dispatch_plan(PLAN, spec, REGISTRY, HANDOFFS)
+    return spec, registry, plan
+
+
+def _reservation(plan, trial_id="PC-RCL-001"):
+    return make_reservation_record(
+        plan,
+        trial_id,
+        [3, 1, 3],
+        reservation_id="a" * 64,
+        reserved_at_utc="2026-09-01T16:10:00Z",
+    )
+
+
+def test_dispatch_plan_matches_frozen_registry_and_handoffs() -> None:
+    spec, registry, plan = _inputs()
+    assert plan["trial_order"] == list(spec.expected_ids)
+    assert len(plan["trials"]) == 32
+    assert plan["trials"][0]["issue_number"] == 18
+    assert plan["trials"][-1]["issue_number"] == 49
+    assert plan["registry_snapshot_sha256"] == guard.sha256_bytes(REGISTRY.read_bytes())
+    assert registry["included_trials_started"] == 0
+
+
+def test_plan_trial_mapping_tamper_is_rejected(tmp_path: Path) -> None:
+    spec, _, _ = _inputs()
+    value = json.loads(PLAN.read_text(encoding="utf-8"))
+    value["trials"][0]["issue_number"] = 999
+    forged = tmp_path / "plan.json"
+    forged.write_text(json.dumps(value), encoding="utf-8")
+    with pytest.raises(ValueError, match="trial record mismatch"):
+        load_dispatch_plan(forged, spec, REGISTRY, HANDOFFS)
+
+
+def test_reservation_is_assignment_free_and_deduplicates_baseline() -> None:
+    _, _, plan = _inputs()
+    record = _reservation(plan)
+    validate_dispatch_record(record, plan)
+    assert record_state(record) == "RESERVED"
+    assert record["baseline_run_ids"] == [1, 3]
+    rendered = json.dumps(record)
+    for forbidden in ("condition", "legibility", "trial_key", "payload_hash"):
+        assert f'"{forbidden}"' not in rendered
+
+
+def test_record_state_machine_rejects_skip() -> None:
+    _, _, plan = _inputs()
+    record = _reservation(plan)
+    with pytest.raises(ValueError, match="invalid dispatch state transition"):
+        append_record_event(record, "REVEALED")
+    record = append_record_event(
+        record, "DISPATCH_SUBMITTED", at_utc="2026-09-01T16:10:01Z"
+    )
+    record = append_record_event(
+        record,
+        "RUN_IDENTIFIED",
+        at_utc="2026-09-01T16:10:02Z",
+        run_id=42,
+    )
+    record = append_record_event(
+        record, "REVEALED", at_utc="2026-09-01T16:10:03Z"
+    )
+    validate_dispatch_record(record, plan)
+    assert record_state(record) == "REVEALED"
+
+
+def _run_row(run_id: int, plan: dict, *, status: str = "queued") -> dict:
+    return {
+        "databaseId": run_id,
+        "event": "workflow_dispatch",
+        "headBranch": plan["controller_tag"],
+        "headSha": plan["controller_commit"],
+        "createdAt": "2026-09-01T16:11:00Z",
+        "status": status,
+        "conclusion": None,
+        "url": f"https://github.com/x/actions/runs/{run_id}",
+        "displayTitle": "rcl-bound-controller",
+    }
+
+
+def test_run_discovery_requires_exactly_one_new_matching_run() -> None:
+    _, _, plan = _inputs()
+    old = _run_row(10, plan, status="completed")
+    new = _run_row(11, plan)
+    other = dict(_run_row(12, plan))
+    other["headSha"] = "0" * 40
+    identified = discover_new_run([10], [old, new, other], plan)
+    assert identified["status"] == "RUN_IDENTIFIED"
+    assert identified["run"]["databaseId"] == 11
+    assert discover_new_run([10], [old], plan)["status"] == "RUN_UNRESOLVED"
+    ambiguous = discover_new_run([10], [old, new, _run_row(13, plan)], plan)
+    assert ambiguous["status"] == "RUN_AMBIGUOUS"
+
+
+def test_fixed_order_requires_prior_terminal_record() -> None:
+    _, _, plan = _inputs()
+    assert_dispatch_order(plan, "PC-RCL-001", {})
+    with pytest.raises(RuntimeError, match="predecessor"):
+        assert_dispatch_order(plan, "PC-RCL-002", {})
+    first = _reservation(plan)
+    first = append_record_event(
+        first, "DISPATCH_SUBMITTED", at_utc="2026-09-01T16:10:01Z"
+    )
+    first = append_record_event(
+        first, "RUN_IDENTIFIED", at_utc="2026-09-01T16:10:02Z", run_id=42
+    )
+    with pytest.raises(RuntimeError, match="nonterminal"):
+        assert_dispatch_order(plan, "PC-RCL-002", {"PC-RCL-001": first})
+    first = append_record_event(
+        first, "ABORTED", at_utc="2026-09-01T16:10:03Z", reason="test"
+    )
+    assert_dispatch_order(plan, "PC-RCL-002", {"PC-RCL-001": first})
+    with pytest.raises(RuntimeError, match="already reserved"):
+        assert_dispatch_order(plan, "PC-RCL-001", {"PC-RCL-001": first})
+
+
+def test_issue_preflight_requires_exact_empty_surface() -> None:
+    spec, registry, plan = _inputs()
+    trial = plan["trials"][0]
+    registered = dict(registry["trials"][0])
+    registered["status"] = "NOT_CREATED"
+    issue = {
+        "number": trial["issue_number"],
+        "url": trial["issue_url"],
+        "title": issue_title(trial["trial_id"]),
+        "body": render_issue_body(registered, registry),
+        "state": "OPEN",
+        "comments": [],
+    }
+    verify_issue_surface(issue, trial, registry, spec)
+    contaminated = dict(issue)
+    contaminated["comments"] = [{"body": "unexpected"}]
+    with pytest.raises(RuntimeError, match="zero_comments"):
+        verify_issue_surface(contaminated, trial, registry, spec)
+
+
+def test_operator_confirmations_are_exact() -> None:
+    spec, _, _ = _inputs()
+    config = json.loads((ROOT / spec.config_path).read_text(encoding="utf-8"))
+    verify_operator_confirmations(
+        config,
+        freeze=spec.freeze_tag,
+        trial="PC-RCL-001",
+        trial_id="PC-RCL-001",
+        model="GPT-5.6 Sol",
+        client="ChatGPT/1.2026.230; iOS 26.6.1",
+        memory="enabled",
+        customization="present",
+        spec=spec,
+    )
+    with pytest.raises(RuntimeError, match="model"):
+        verify_operator_confirmations(
+            config,
+            freeze=spec.freeze_tag,
+            trial="PC-RCL-001",
+            trial_id="PC-RCL-001",
+            model="GPT-5.6 Pro",
+            client="ChatGPT/1.2026.230; iOS 26.6.1",
+            memory="enabled",
+            customization="present",
+            spec=spec,
+        )
+
+
+def _exact_issue(spec, registry, plan):
+    trial = plan["trials"][0]
+    body_trial = dict(registry["trials"][0])
+    body_trial["status"] = "NOT_CREATED"
+    return {
+        "number": trial["issue_number"],
+        "url": trial["issue_url"],
+        "title": issue_title(trial["trial_id"]),
+        "body": render_issue_body(body_trial, registry),
+        "state": "OPEN",
+        "comments": [],
+    }
+
+
+def test_dispatch_apply_persists_reservation_before_external_dispatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    spec, registry, plan = _inputs()
+    order: list[str] = []
+    monkeypatch.setattr(guard, "preflight", lambda **kwargs: {"ready": True})
+    monkeypatch.setattr(guard, "_gh", lambda value=None: "gh")
+    monkeypatch.setattr(guard, "prepare_dispatch_ledger", lambda *a, **k: tmp_path)
+    monkeypatch.setattr(guard, "load_dispatch_records", lambda *a, **k: {})
+    monkeypatch.setattr(guard, "_issue_from_gh", lambda *a, **k: _exact_issue(spec, registry, plan))
+    monkeypatch.setattr(guard, "_controller_runs", lambda *a, **k: [])
+
+    def fake_persist(ledger, record, plan_value, *, action):
+        order.append("persist:" + record_state(record))
+        return "d" * 40
+
+    def fake_dispatch(*args, **kwargs):
+        assert order == ["persist:RESERVED"]
+        order.append("dispatch")
+        return subprocess.CompletedProcess(["gh"], 0, stdout="", stderr="")
+
+    monkeypatch.setattr(guard, "persist_dispatch_record", fake_persist)
+    monkeypatch.setattr(guard, "_dispatch_command", fake_dispatch)
+    monkeypatch.setattr(
+        guard,
+        "_poll_for_new_run",
+        lambda *a, **k: {
+            "status": "RUN_IDENTIFIED",
+            "run": _run_row(77, plan),
+            "candidates": [_run_row(77, plan)],
+        },
+    )
+    report = guard.dispatch_once(
+        trial_id="PC-RCL-001",
+        repo_root=ROOT,
+        ledger_dir=tmp_path,
+        plan_path=PLAN,
+        manifest_path=MANIFEST,
+        registry_path=REGISTRY,
+        handoff_manifest_path=HANDOFFS,
+        apply=True,
+        confirm_freeze=spec.freeze_tag,
+        confirm_trial="PC-RCL-001",
+        confirm_model="GPT-5.6 Sol",
+        confirm_client="ChatGPT/1.2026.230; iOS 26.6.1",
+        confirm_memory="enabled",
+        confirm_customization="present",
+    )
+    assert order == [
+        "persist:RESERVED",
+        "dispatch",
+        "persist:DISPATCH_SUBMITTED",
+        "persist:RUN_IDENTIFIED",
+    ]
+    assert report["run_discovery"]["run"]["databaseId"] == 77
+    assert report["automatic_retry_allowed"] is False
+
+
+def test_dispatch_dry_run_has_no_reservation_or_external_dispatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        guard,
+        "preflight",
+        lambda **kwargs: {
+            "ready": True,
+            "trial_id": "PC-RCL-001",
+            "issue_number": 18,
+            "included_registry_started": 0,
+        },
+    )
+    monkeypatch.setattr(
+        guard,
+        "prepare_dispatch_ledger",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("must not reserve")),
+    )
+    monkeypatch.setattr(
+        guard,
+        "_dispatch_command",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("must not dispatch")),
+    )
+    report = guard.dispatch_once(
+        trial_id="PC-RCL-001",
+        repo_root=ROOT,
+        ledger_dir=tmp_path,
+        plan_path=PLAN,
+        manifest_path=MANIFEST,
+        registry_path=REGISTRY,
+        handoff_manifest_path=HANDOFFS,
+        apply=False,
+    )
+    assert report["mode"] == "DRY_RUN"
+    assert report["included_registry_started"] == 0
+
+
+def test_failed_dispatch_command_is_consumed_and_never_retried(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    spec, registry, plan = _inputs()
+    states: list[str] = []
+    dispatch_count = 0
+    monkeypatch.setattr(guard, "preflight", lambda **kwargs: {"ready": True})
+    monkeypatch.setattr(guard, "_gh", lambda value=None: "gh")
+    monkeypatch.setattr(guard, "prepare_dispatch_ledger", lambda *a, **k: tmp_path)
+    monkeypatch.setattr(guard, "load_dispatch_records", lambda *a, **k: {})
+    monkeypatch.setattr(guard, "_issue_from_gh", lambda *a, **k: _exact_issue(spec, registry, plan))
+    monkeypatch.setattr(guard, "_controller_runs", lambda *a, **k: [])
+    monkeypatch.setattr(
+        guard,
+        "persist_dispatch_record",
+        lambda ledger, record, plan_value, *, action: states.append(record_state(record)) or "d" * 40,
+    )
+
+    def failed(*args, **kwargs):
+        nonlocal dispatch_count
+        dispatch_count += 1
+        return subprocess.CompletedProcess(["gh"], 1, stdout="", stderr="network uncertain")
+
+    monkeypatch.setattr(guard, "_dispatch_command", failed)
+    monkeypatch.setattr(
+        guard,
+        "_poll_for_new_run",
+        lambda *a, **k: {"status": "RUN_UNRESOLVED", "run": None, "candidates": []},
+    )
+    report = guard.dispatch_once(
+        trial_id="PC-RCL-001", repo_root=ROOT, ledger_dir=tmp_path,
+        plan_path=PLAN, manifest_path=MANIFEST, registry_path=REGISTRY,
+        handoff_manifest_path=HANDOFFS, apply=True,
+        confirm_freeze=spec.freeze_tag, confirm_trial="PC-RCL-001",
+        confirm_model="GPT-5.6 Sol",
+        confirm_client="ChatGPT/1.2026.230; iOS 26.6.1",
+        confirm_memory="enabled", confirm_customization="present", poll_seconds=0,
+    )
+    assert dispatch_count == 1
+    assert states == ["RESERVED", "DISPATCH_COMMAND_FAILED_UNCERTAIN", "RUN_UNRESOLVED"]
+    assert report["automatic_retry_allowed"] is False
+
+
+def _git(cwd: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=cwd, check=True, capture_output=True, text=True
+    )
+    return result.stdout.strip()
+
+
+def test_dispatch_ledger_initialization_and_reservation_are_durable(
+    tmp_path: Path,
+) -> None:
+    _, _, plan = _inputs()
+    bare = tmp_path / "remote.git"
+    subprocess.run(["git", "init", "--bare", str(bare)], check=True, capture_output=True)
+    admin = tmp_path / "admin"
+    subprocess.run(["git", "clone", str(bare), str(admin)], check=True, capture_output=True)
+    _git(admin, "config", "user.name", "test")
+    _git(admin, "config", "user.email", "test@example.com")
+    (admin / "README.md").write_text("base\n", encoding="utf-8")
+    _git(admin, "add", "README.md")
+    _git(admin, "commit", "-m", "base")
+    _git(admin, "branch", "-M", "main")
+    _git(admin, "push", "-u", "origin", "main")
+
+    ledger = tmp_path / "ledger"
+    prepared = guard.prepare_dispatch_ledger(admin, ledger, PLAN, plan)
+    assert prepared == ledger.resolve()
+    heads = _git(admin, "ls-remote", "--heads", "origin", "refs/heads/rcl-dispatch-ledger")
+    assert "refs/heads/rcl-dispatch-ledger" in heads
+    assert (ledger / "rcl-dispatch/MANIFEST.json").is_file()
+
+    record = _reservation(plan)
+    commit = guard.persist_dispatch_record(ledger, record, plan, action="reserve")
+    assert len(commit) == 40
+    assert (ledger / "rcl-dispatch/PC-RCL-001.json").is_file()
+
+    second = tmp_path / "ledger-second"
+    guard.prepare_dispatch_ledger(admin, second, PLAN, plan)
+    records = guard.load_dispatch_records(second, plan)
+    assert record_state(records["PC-RCL-001"]) == "RESERVED"
+    assert records["PC-RCL-001"]["reservation_id"] == "a" * 64
+    recovered = append_record_event(
+        records["PC-RCL-001"],
+        "DISPATCH_SUBMITTED",
+        at_utc="2026-09-01T16:10:01Z",
+        returncode=0,
+    )
+    second_commit = guard.persist_dispatch_record(
+        second, recovered, plan, action="recover-submit"
+    )
+    assert len(second_commit) == 40
+    third = tmp_path / "ledger-third"
+    guard.prepare_dispatch_ledger(admin, third, PLAN, plan)
+    latest = guard.load_dispatch_records(third, plan)["PC-RCL-001"]
+    assert record_state(latest) == "DISPATCH_SUBMITTED"
+
+
+def test_dispatch_events_forbid_hidden_assignment_material() -> None:
+    _, _, plan = _inputs()
+    record = _reservation(plan)
+    with pytest.raises(ValueError, match="hidden assignment"):
+        append_record_event(record, "DISPATCH_SUBMITTED", condition="available")
+
+
+def _identified_record(plan):
+    record = _reservation(plan)
+    record = append_record_event(
+        record, "DISPATCH_SUBMITTED", at_utc="2026-09-01T16:10:01Z"
+    )
+    return append_record_event(
+        record,
+        "RUN_IDENTIFIED",
+        at_utc="2026-09-01T16:10:02Z",
+        run_id=77,
+        run_url="https://github.com/x/actions/runs/77",
+    )
+
+
+def test_reconcile_marks_reveal_without_touching_behavioral_payload(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    spec, registry, plan = _inputs()
+    record = _identified_record(plan)
+    monkeypatch.setattr(guard, "_gh", lambda value=None: "gh")
+    monkeypatch.setattr(guard, "prepare_dispatch_ledger", lambda *a, **k: tmp_path)
+    monkeypatch.setattr(
+        guard, "load_dispatch_records", lambda *a, **k: {"PC-RCL-001": record}
+    )
+    monkeypatch.setattr(
+        guard,
+        "_run_view",
+        lambda *a, **k: {
+            "databaseId": 77,
+            "event": "workflow_dispatch",
+            "headBranch": plan["controller_tag"],
+            "headSha": plan["controller_commit"],
+            "status": "completed",
+            "conclusion": "success",
+            "url": "https://github.com/x/actions/runs/77",
+        },
+    )
+    issue = _exact_issue(spec, registry, plan)
+    issue["comments"] = [
+        {"body": "SAIS_RCL_READY {}"},
+        {"body": "SAIS_RCL_REVEAL {}"},
+    ]
+    monkeypatch.setattr(guard, "_issue_from_gh", lambda *a, **k: issue)
+    seen = {}
+
+    def persist(ledger, updated, plan_value, *, action):
+        seen["record"] = updated
+        return "e" * 40
+
+    monkeypatch.setattr(guard, "persist_dispatch_record", persist)
+    report = guard.reconcile_trial(
+        trial_id="PC-RCL-001", repo_root=ROOT, ledger_dir=tmp_path,
+        plan_path=PLAN, manifest_path=MANIFEST, registry_path=REGISTRY,
+        handoff_manifest_path=HANDOFFS,
+    )
+    assert report["state"] == "REVEALED"
+    assert record_state(seen["record"]) == "REVEALED"
+    assert not guard.FORBIDDEN_DISPATCH_KEYS.intersection(json.loads(json.dumps(seen["record"])))
+
+
+def test_post_reservation_run_race_blocks_local_dispatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    spec, registry, plan = _inputs()
+    persisted: list[str] = []
+    run_calls = 0
+    monkeypatch.setattr(guard, "preflight", lambda **kwargs: {"ready": True})
+    monkeypatch.setattr(guard, "_gh", lambda value=None: "gh")
+    monkeypatch.setattr(guard, "prepare_dispatch_ledger", lambda *a, **k: tmp_path)
+    monkeypatch.setattr(guard, "load_dispatch_records", lambda *a, **k: {})
+    monkeypatch.setattr(guard, "_issue_from_gh", lambda *a, **k: _exact_issue(spec, registry, plan))
+
+    def runs(*args, **kwargs):
+        nonlocal run_calls
+        run_calls += 1
+        return [] if run_calls == 1 else [_run_row(88, plan)]
+
+    monkeypatch.setattr(guard, "_controller_runs", runs)
+    monkeypatch.setattr(
+        guard,
+        "persist_dispatch_record",
+        lambda ledger, record, plan_value, *, action: persisted.append(record_state(record)) or "f" * 40,
+    )
+    monkeypatch.setattr(
+        guard,
+        "_dispatch_command",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("dispatch must be blocked")),
+    )
+    report = guard.dispatch_once(
+        trial_id="PC-RCL-001", repo_root=ROOT, ledger_dir=tmp_path,
+        plan_path=PLAN, manifest_path=MANIFEST, registry_path=REGISTRY,
+        handoff_manifest_path=HANDOFFS, apply=True,
+        confirm_freeze=spec.freeze_tag, confirm_trial="PC-RCL-001",
+        confirm_model="GPT-5.6 Sol",
+        confirm_client="ChatGPT/1.2026.230; iOS 26.6.1",
+        confirm_memory="enabled", confirm_customization="present",
+    )
+    assert report["mode"] == "APPLY_BLOCKED_PRE_DISPATCH"
+    assert report["external_dispatch_performed"] is False
+    assert persisted == ["RESERVED", "RUN_AMBIGUOUS"]
+
+
+def test_post_reservation_issue_change_aborts_before_dispatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    spec, registry, plan = _inputs()
+    calls = 0
+    monkeypatch.setattr(guard, "preflight", lambda **kwargs: {"ready": True})
+    monkeypatch.setattr(guard, "_gh", lambda value=None: "gh")
+    monkeypatch.setattr(guard, "prepare_dispatch_ledger", lambda *a, **k: tmp_path)
+    monkeypatch.setattr(guard, "load_dispatch_records", lambda *a, **k: {})
+
+    def issue(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        value = _exact_issue(spec, registry, plan)
+        if calls > 1:
+            value["comments"] = [{"body": "changed"}]
+        return value
+
+    monkeypatch.setattr(guard, "_issue_from_gh", issue)
+    monkeypatch.setattr(guard, "_controller_runs", lambda *a, **k: [])
+    states: list[str] = []
+    monkeypatch.setattr(
+        guard,
+        "persist_dispatch_record",
+        lambda ledger, record, plan_value, *, action: states.append(record_state(record)) or "f" * 40,
+    )
+    monkeypatch.setattr(
+        guard,
+        "_dispatch_command",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("dispatch must be blocked")),
+    )
+    report = guard.dispatch_once(
+        trial_id="PC-RCL-001", repo_root=ROOT, ledger_dir=tmp_path,
+        plan_path=PLAN, manifest_path=MANIFEST, registry_path=REGISTRY,
+        handoff_manifest_path=HANDOFFS, apply=True,
+        confirm_freeze=spec.freeze_tag, confirm_trial="PC-RCL-001",
+        confirm_model="GPT-5.6 Sol",
+        confirm_client="ChatGPT/1.2026.230; iOS 26.6.1",
+        confirm_memory="enabled", confirm_customization="present",
+    )
+    assert report["mode"] == "APPLY_ABORTED_PRE_DISPATCH"
+    assert states == ["RESERVED", "ABORTED"]


### PR DESCRIPTION
## Purpose
Make the first live RCL-PC dispatch recoverable under network/process interruption without changing the frozen controller or starting a trial in this PR.

## Core invariant
A durable reservation on a dedicated Git branch must be pushed **before** any external workflow dispatch. A reserved identifier is never blindly redispatched.

## Dispatch guard
- validates v2 freeze/controller/config tags and SHAs
- validates exact registry snapshot, handoff manifest, per-trial issue mapping, and precommitted handoff hash
- live-checks the dedicated issue title/body/open state/zero comments
- enforces fixed order `PC-RCL-001` → `032`
- enforces maximum one active dispatch
- records the complete baseline set of matching controller workflow run IDs
- persists `RESERVED` to `rcl-dispatch-ledger` before workflow dispatch
- validates the dispatch-ledger manifest itself against plan/freeze/controller/config anchors
- stores only hashes/lengths of CLI stdout/stderr, never raw command output
- rechecks the issue and matching run set *after reservation* and before dispatch, blocking on any race
- discovers a unique new run only if it matches `workflow_dispatch + controller tag + controller SHA`
- zero new runs → `RUN_UNRESOLVED`; multiple → `RUN_AMBIGUOUS`
- no automatic retry after reservation
- supports recovery after a crash and reconciliation to READY/REVEALED/ABORTED
- forbids hidden condition/legibility/key/payload material in dispatch records/events
- configures commit identity on fresh dispatch-ledger clones so recovery works from a new checkout

## Product-state gate
Apply mode requires exact explicit confirmation of:
- freeze tag
- trial ID
- model label `GPT-5.6 Sol`
- client build `ChatGPT/1.2026.230; iOS 26.6.1`
- memory state `enabled`
- customization state `present`

## Live read-only preflight
`PC-RCL-001` currently passes live preflight:
- issue `#18`
- zero comments
- handoff SHA `e9d6c6bd25ee2b60e97470e862c8fcc0963964f18227da38d3656cb94c54814c`
- baseline matching controller runs: empty
- prior dispatch records: empty
- included registry started: `0`

Dry-run created no dispatch-ledger branch and no issue comment/run.

## Gates
- `151 passed`
- live PC-RCL-001 preflight PASS
- temporary bare-Git durability test covers initialize → reserve → fresh clone → recovery commit → third clone verification
- post-reservation issue/run race tests PASS and prove no dispatch occurs on changed state
- secret scan PASS
- diff check PASS

## Boundary
This PR does not initialize a live dispatch ledger, reserve an identifier, dispatch the controller, or start any included trial. Actual apply is deferred until the fresh subject conversation is prepared.